### PR TITLE
Fix 5 bugs found during code review

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -29,7 +29,17 @@ async def _scheduled_refresh():
         try:
             logger.info("Scheduled refresh starting")
             from app.routers.pipeline import pipeline as pl
-            result = await pl.ainvoke({"force": False})
+            from workflows.pipeline_workflow import PipelineState
+            initial_state: PipelineState = {
+                "force": False,
+                "articles": [],
+                "new_articles": [],
+                "summaries": {},
+                "embeddings": {},
+                "results": {},
+                "errors": [],
+            }
+            result = await pl.ainvoke(initial_state)
             errors = result.get("errors", [])
             results = result.get("results", {})
             logger.info("Scheduled refresh done: %s categories, %d errors", len(results), len(errors))

--- a/services/rss.py
+++ b/services/rss.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import calendar
 import ctypes
 import logging
 from datetime import datetime, timezone
@@ -119,7 +120,7 @@ FEEDS: list[tuple[str, str]] = [
     ("The Lancet", "https://www.thelancet.com/rssfeed/lancet_current.xml"),
     ("Healio", "https://www.healio.com/rss"),
     # ── Politics ────────────────────────────────────────
-    ("Politico", "https://rss.politico.com/congress.xml"),
+    ("Politico Congress", "https://rss.politico.com/congress.xml"),
     ("The Hill Politics", "https://thehill.com/homenews/feed/"),
     ("RealClearPolitics", "https://feeds.feedburner.com/realclearpolitics/qlMj"),
     ("FiveThirtyEight", "https://fivethirtyeight.com/features/feed/"),
@@ -324,8 +325,7 @@ def _parse_date(entry) -> datetime | None:
         parsed = entry.get(field)
         if parsed:
             try:
-                from time import mktime
-                return datetime.fromtimestamp(mktime(parsed), tz=timezone.utc)
+                return datetime.fromtimestamp(calendar.timegm(parsed), tz=timezone.utc)
             except Exception:
                 continue
 
@@ -333,7 +333,10 @@ def _parse_date(entry) -> datetime | None:
         raw = entry.get(field, "")
         if raw:
             try:
-                return parsedate_to_datetime(raw).replace(tzinfo=timezone.utc)
+                dt = parsedate_to_datetime(raw)
+                if dt.tzinfo is None:
+                    dt = dt.replace(tzinfo=timezone.utc)
+                return dt
             except Exception:
                 try:
                     return datetime.fromisoformat(raw.replace("Z", "+00:00"))

--- a/workflows/pipeline_workflow.py
+++ b/workflows/pipeline_workflow.py
@@ -149,26 +149,29 @@ async def store_node(state: PipelineState) -> dict:
 
     pool = await get_pool()
 
-    # Count by category for results
-    all_by_cat: dict[str, int] = {}
-    for a in all_articles:
-        cat = a.category or "top"
-        all_by_cat[cat] = all_by_cat.get(cat, 0) + 1
-
+    # Count new articles by category (categories are assigned during summarization)
     new_by_cat: dict[str, list[RSSArticle]] = {}
     for a in new_articles:
         cat = a.category or "top"
         new_by_cat.setdefault(cat, []).append(a)
 
+    # Skipped = total fetched - total new (categories aren't available for
+    # skipped articles since they never went through summarization, so we
+    # can only report the total skipped count, not per-category)
+    total_skipped = len(all_articles) - len(new_articles)
+
     results: dict[str, CategoryResult] = {}
     for cat in ALL_CATEGORIES:
         new_count = len(new_by_cat.get(cat, []))
-        total_fetched = all_by_cat.get(cat, 0)
         results[cat] = CategoryResult(
             new_articles=new_count,
-            skipped=max(0, total_fetched - new_count),
+            skipped=0,
             errors=0,
         )
+
+    # Attribute total skipped count to "top" as a summary figure
+    if total_skipped > 0:
+        results["top"].skipped = total_skipped
 
     # Upsert each new article
     stored = 0


### PR DESCRIPTION
## Summary

- **Fix wrong publication dates on non-UTC servers**: `time.mktime()` interprets feedparser's UTC-normalized timestamps as local time, causing dates to be off by the server's timezone offset. Replaced with `calendar.timegm()`.
- **Fix `parsedate_to_datetime` overwriting existing timezone**: `.replace(tzinfo=utc)` silently overwrote valid timezone info. Now only sets UTC when timezone is absent.
- **Fix pipeline "skipped" count always being 0**: Raw fetched articles have `category=""` which doesn't match any valid category, so `all_by_cat.get(cat, 0)` always returned 0. Reworked to compute total skipped correctly.
- **Fix scheduled refresh passing incomplete initial state**: Was passing only `{"force": False}` missing 6 required `PipelineState` keys. Now passes the full initial state matching how the router invokes the pipeline.
- **Fix duplicate "Politico" source name**: Two different feeds (general + congress) both named "Politico", making articles indistinguishable. Renamed congress feed to "Politico Congress".

## Test plan

- [ ] Verify publication dates are correct after a pipeline refresh (especially on non-UTC servers)
- [ ] Verify pipeline response includes non-zero `skipped` counts when duplicate articles exist
- [ ] Confirm scheduled background refresh runs without errors in production logs
- [ ] Check that articles from `rss.politico.com/congress.xml` appear as "Politico Congress"