### PR TITLE
Comprehensive UI/UX and professional polish review

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,17 +57,22 @@ curl -X POST http://localhost:8000/pipeline/refresh \
 # Multi-source comparison
 curl -X POST http://localhost:8000/analyze/compare \
   -H "Content-Type: application/json" \
+  -H "X-Pipeline-Key: dev-key" \
   -d '{"topic": "Federal Reserve interest rate decision", "sources": ["reuters", "bbc", "associated press"]}'
 ```
 
 ## API
 
+All endpoints are available at both `/v1/...` (preferred) and legacy paths (for backwards compatibility).
+
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | GET | `/` | Service info + available endpoints |
 | GET | `/health` | Health check + DB status + last pipeline run |
-| POST | `/pipeline/refresh` | Trigger RSS pipeline (auth required) |
-| POST | `/analyze/compare` | Multi-source comparison via LangGraph |
+| GET | `/docs` | Interactive API documentation (Swagger UI) |
+| GET | `/redoc` | Alternative API documentation (ReDoc) |
+| POST | `/v1/pipeline/refresh` | Trigger RSS pipeline (auth required) |
+| POST | `/v1/analyze/compare` | Multi-source comparison via LangGraph |
 
 ## Project structure
 
@@ -87,7 +92,7 @@ sift-api/
 ├── services/
 │   ├── rss.py               # 100+ RSS feeds, feedparser, image extraction
 │   ├── summarizer.py        # Claude Haiku 4.5 batch summarization
-│   ├── embedder.py          # Voyage AI embeddings (voyage-3-lite, 1024-dim)
+│   ├── embedder.py          # Voyage AI embeddings (voyage-3-lite, 512-dim)
 │   └── deduplicator.py      # Postgres dedup check
 ├── tests/
 ├── docker-compose.yml       # Postgres 16 + pgvector (local dev)

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+limiter = Limiter(key_func=get_remote_address)

--- a/app/main.py
+++ b/app/main.py
@@ -2,22 +2,24 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import uuid
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
-from slowapi import Limiter
-from slowapi.util import get_remote_address
 from slowapi.errors import RateLimitExceeded
 
 from app.config import settings
 from app.db import init_pool, get_pool, close_pool
+from app.dependencies import limiter
 from app.models import HealthResponse
 from app.routers import pipeline, compare
 
 logger = logging.getLogger("sift-api")
+
+API_VERSION = "1.0.0"
 
 REFRESH_INTERVAL = 10 * 60  # 10 minutes
 
@@ -79,11 +81,14 @@ async def lifespan(app: FastAPI):
     logger.info("sift-api shut down")
 
 
-limiter = Limiter(key_func=get_remote_address)
-
 app = FastAPI(
     title="Sift API",
-    version="0.1.0",
+    version=API_VERSION,
+    description=(
+        "AI-curated news pipeline and multi-source comparison API for Sift. "
+        "Handles background content processing (RSS feeds, Claude summaries, "
+        "Voyage AI embeddings) and on-demand multi-source news comparison."
+    ),
     lifespan=lifespan,
 )
 
@@ -100,11 +105,17 @@ async def rate_limit_handler(request: Request, exc: RateLimitExceeded):
 
 class SecurityHeadersMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
+        # Generate or echo request ID for tracing
+        request_id = request.headers.get("X-Request-ID") or str(uuid.uuid4())
+
         response = await call_next(request)
+        response.headers["X-Request-ID"] = request_id
         response.headers["X-Content-Type-Options"] = "nosniff"
         response.headers["X-Frame-Options"] = "DENY"
-        response.headers["X-XSS-Protection"] = "1; mode=block"
+        response.headers["Content-Security-Policy"] = "default-src 'none'; frame-ancestors 'none'"
+        response.headers["Permissions-Policy"] = "()"
         response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        response.headers["Content-Language"] = "en"
         if settings.environment == "production":
             response.headers["Strict-Transport-Security"] = (
                 "max-age=63072000; includeSubDomains; preload"
@@ -127,24 +138,40 @@ app.add_middleware(
     allow_headers=["Content-Type", "X-Pipeline-Key"],
 )
 
+# Versioned routes (preferred)
+app.include_router(pipeline.router, prefix="/v1")
+app.include_router(compare.router, prefix="/v1")
+
+# Legacy routes (backwards-compatible, migrate frontend then remove)
 app.include_router(pipeline.router)
 app.include_router(compare.router)
 
 
-@app.get("/")
+@app.get(
+    "/",
+    summary="Service info",
+    description="Returns service metadata and available API endpoints.",
+)
 async def root():
     return {
         "service": "sift-api",
-        "version": "0.1.0",
+        "version": API_VERSION,
         "endpoints": {
             "health": "GET /health",
-            "pipeline": "POST /pipeline/refresh",
-            "compare": "POST /analyze/compare",
+            "pipeline": "POST /v1/pipeline/refresh",
+            "compare": "POST /v1/analyze/compare",
+            "docs": "GET /docs",
+            "redoc": "GET /redoc",
         },
     }
 
 
-@app.get("/health", response_model=HealthResponse)
+@app.get(
+    "/health",
+    response_model=HealthResponse,
+    summary="Health check",
+    description="Returns service health, database connectivity, and last pipeline run timestamp.",
+)
 async def health():
     db_connected = False
     last_run = None
@@ -159,9 +186,15 @@ async def health():
             last_run = row["last_run"].isoformat()
     except Exception:
         pass
+
+    scheduler_running = (
+        settings.environment == "production" or None
+    )
+
     return HealthResponse(
-        status="healthy",
-        version="0.1.0",
+        status="healthy" if db_connected else "degraded",
+        version=API_VERSION,
         db_connected=db_connected,
         last_pipeline_run=last_run,
+        scheduler_running=scheduler_running if scheduler_running else None,
     )

--- a/app/models.py
+++ b/app/models.py
@@ -18,6 +18,7 @@ class CategoryResult(BaseModel):
 
 class PipelineResponse(BaseModel):
     results: dict[str, CategoryResult]
+    total_skipped: int = 0
     duration_ms: int
 
 
@@ -43,7 +44,7 @@ class CompareResponse(BaseModel):
     topic: str
     comparison: str
     sources_checked: list[str]
-    claims: list[dict]
+    claims: list[Claim]
     duration_ms: int
 
 
@@ -54,6 +55,14 @@ class HealthResponse(BaseModel):
     version: str
     db_connected: bool
     last_pipeline_run: str | None
+    scheduler_running: bool | None = None
+
+
+# --- Errors ---
+
+class ErrorResponse(BaseModel):
+    detail: str
+    code: str
 
 
 # --- Internal: RSS article before summarization ---

--- a/app/routers/compare.py
+++ b/app/routers/compare.py
@@ -4,23 +4,34 @@ import hmac
 import logging
 import time
 
+import asyncio
+
 from fastapi import APIRouter, Header, HTTPException, Request
-from slowapi import Limiter
-from slowapi.util import get_remote_address
 
 from app.config import settings
+from app.dependencies import limiter
 from app.models import CompareRequest, CompareResponse
 from workflows.compare_workflow import build_compare_graph, CompareState
 
 logger = logging.getLogger("sift-api.compare-router")
 
-limiter = Limiter(key_func=get_remote_address)
 router = APIRouter(prefix="/analyze", tags=["compare"])
+
+COMPARE_TIMEOUT = 90  # seconds — max time for entire comparison workflow
 
 compare_graph = build_compare_graph()
 
 
-@router.post("/compare", response_model=CompareResponse)
+@router.post(
+    "/compare",
+    response_model=CompareResponse,
+    summary="Multi-source news comparison",
+    description=(
+        "Searches multiple news sources for coverage of a topic, extracts key claims, "
+        "and compares how sources agree or disagree. Supports up to 5 sources. "
+        "Rate limited to 10 requests per minute. May take up to 90 seconds."
+    ),
+)
 @limiter.limit("10/minute")
 async def compare_sources(
     request: Request,
@@ -59,10 +70,22 @@ async def compare_sources(
     }
 
     try:
-        result = await compare_graph.ainvoke(initial_state)
+        result = await asyncio.wait_for(
+            compare_graph.ainvoke(initial_state),
+            timeout=COMPARE_TIMEOUT,
+        )
+    except asyncio.TimeoutError:
+        logger.error("Compare workflow timed out after %ds", COMPARE_TIMEOUT)
+        raise HTTPException(
+            status_code=504,
+            detail={"detail": "Comparison timed out. Try fewer sources or a simpler topic.", "code": "COMPARISON_TIMEOUT"},
+        )
     except Exception as e:
         logger.error("Compare workflow failed: %s", e)
-        raise HTTPException(status_code=500, detail="Comparison failed")
+        raise HTTPException(
+            status_code=500,
+            detail={"detail": "Comparison failed", "code": "COMPARISON_FAILED"},
+        )
 
     duration_ms = int((time.time() - start) * 1000)
 
@@ -76,7 +99,10 @@ async def compare_sources(
     if not comparison and not claims:
         raise HTTPException(
             status_code=502,
-            detail="Could not generate comparison. The sources may not have relevant coverage.",
+            detail={
+                "detail": "Could not generate comparison. The sources may not have relevant coverage.",
+                "code": "NO_COVERAGE",
+            },
         )
 
     # Report only the sources that were actually searched (present in search_results)

--- a/app/routers/pipeline.py
+++ b/app/routers/pipeline.py
@@ -5,22 +5,29 @@ import logging
 import time
 
 from fastapi import APIRouter, Header, HTTPException, Request
-from slowapi import Limiter
-from slowapi.util import get_remote_address
 
 from app.config import settings
+from app.dependencies import limiter
 from app.models import PipelineRequest, PipelineResponse
 from workflows.pipeline_workflow import build_pipeline_graph, PipelineState
 
 logger = logging.getLogger("sift-api.pipeline-router")
 
-limiter = Limiter(key_func=get_remote_address)
 router = APIRouter(prefix="/pipeline", tags=["pipeline"])
 
 pipeline = build_pipeline_graph()
 
 
-@router.post("/refresh", response_model=PipelineResponse)
+@router.post(
+    "/refresh",
+    response_model=PipelineResponse,
+    summary="Trigger RSS pipeline",
+    description=(
+        "Triggers the full content pipeline: fetch RSS feeds, deduplicate, "
+        "summarize with Claude, generate embeddings, and store in Postgres. "
+        "Rate limited to 5 requests per minute."
+    ),
+)
 @limiter.limit("5/minute")
 async def refresh_pipeline(
     request: Request,
@@ -46,7 +53,10 @@ async def refresh_pipeline(
         result = await pipeline.ainvoke(initial_state)
     except Exception as e:
         logger.error("Pipeline failed: %s", e)
-        raise HTTPException(status_code=500, detail="Pipeline execution failed")
+        raise HTTPException(
+            status_code=500,
+            detail={"detail": "Pipeline execution failed", "code": "PIPELINE_FAILED"},
+        )
 
     duration_ms = int((time.time() - start) * 1000)
 
@@ -56,5 +66,6 @@ async def refresh_pipeline(
 
     return PipelineResponse(
         results=result.get("results", {}),
+        total_skipped=result.get("total_skipped", 0),
         duration_ms=duration_ms,
     )

--- a/init.sql
+++ b/init.sql
@@ -15,7 +15,7 @@ CREATE TABLE IF NOT EXISTS articles (
     published_date TIMESTAMPTZ,
     embedding VECTOR(512),
     read_time INTEGER DEFAULT 1,
-    from_search BOOLEAN NOT NULL DEFAULT false,
+    from_search BOOLEAN NOT NULL DEFAULT false, -- TODO: set true when compare-discovered articles are persisted
     created_at TIMESTAMPTZ DEFAULT NOW(),
     updated_at TIMESTAMPTZ DEFAULT NOW()
 );
@@ -27,6 +27,10 @@ CREATE INDEX IF NOT EXISTS idx_articles_category_date
 -- Run after initial data load:
 -- CREATE INDEX idx_articles_embedding ON articles
 --     USING ivfflat (embedding vector_cosine_ops) WITH (lists = 20);
+
+-- TODO: Custom topics and bookmarks tables below are consumed by the
+-- Next.js frontend via Neon/Supabase client. API endpoints for these
+-- are planned for a future release.
 
 -- Custom topics: user-defined search topics with embeddings
 CREATE TABLE IF NOT EXISTS custom_topics (

--- a/services/rss.py
+++ b/services/rss.py
@@ -207,7 +207,7 @@ async def _fetch_single_feed(
             resp = await client.get(
                 feed_url,
                 timeout=FETCH_TIMEOUT,
-                headers={"User-Agent": "Sift/2.0 (+https://siftnews.kristenmartino.ai)"},
+                headers={"User-Agent": "Sift/1.0 (+https://siftnews.kristenmartino.ai)"},
                 follow_redirects=True,
             )
             resp.raise_for_status()

--- a/services/summarizer.py
+++ b/services/summarizer.py
@@ -25,7 +25,7 @@ async def summarize_articles(articles: list[RSSArticle]) -> dict[str, dict]:
     if not articles:
         return {}
 
-    client = anthropic.AsyncAnthropic(api_key=settings.anthropic_api_key)
+    client = anthropic.AsyncAnthropic(api_key=settings.anthropic_api_key, max_retries=2)
     results: dict[str, dict] = {}
 
     for i in range(0, len(articles), BATCH_SIZE):

--- a/tests/test_compare_router.py
+++ b/tests/test_compare_router.py
@@ -108,5 +108,7 @@ class TestCompareErrorSanitization:
                 headers={"X-Pipeline-Key": "dev-key"},
             )
             assert response.status_code == 500
-            assert "secret" not in response.json()["detail"]
-            assert response.json()["detail"] == "Comparison failed"
+            detail = response.json()["detail"]
+            assert "secret" not in str(detail)
+            assert detail["detail"] == "Comparison failed"
+            assert detail["code"] == "COMPARISON_FAILED"

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -19,12 +19,12 @@ def client():
 
 class TestHealthEndpoint:
     def test_health_no_db(self, client):
-        """Health endpoint returns healthy even without DB."""
+        """Health endpoint returns degraded when DB is unavailable."""
         response = client.get("/health")
         assert response.status_code == 200
         data = response.json()
-        assert data["status"] == "healthy"
-        assert data["version"] == "0.1.0"
+        assert data["status"] == "degraded"
+        assert data["version"] == "1.0.0"
         assert data["db_connected"] is False
 
     def test_health_with_db(self):

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -25,9 +25,33 @@ class TestSecurityHeaders:
         response = client.get("/health")
         assert response.headers["X-Frame-Options"] == "DENY"
 
-    def test_x_xss_protection(self, client):
+    def test_content_security_policy(self, client):
         response = client.get("/health")
-        assert response.headers["X-XSS-Protection"] == "1; mode=block"
+        assert response.headers["Content-Security-Policy"] == "default-src 'none'; frame-ancestors 'none'"
+
+    def test_permissions_policy(self, client):
+        response = client.get("/health")
+        assert response.headers["Permissions-Policy"] == "()"
+
+    def test_content_language(self, client):
+        response = client.get("/health")
+        assert response.headers["Content-Language"] == "en"
+
+    def test_request_id_generated(self, client):
+        response = client.get("/health")
+        assert "X-Request-ID" in response.headers
+        # Should be a valid UUID
+        import uuid
+        uuid.UUID(response.headers["X-Request-ID"])
+
+    def test_request_id_echoed(self, client):
+        custom_id = "test-request-123"
+        response = client.get("/health", headers={"X-Request-ID": custom_id})
+        assert response.headers["X-Request-ID"] == custom_id
+
+    def test_no_deprecated_xss_protection(self, client):
+        response = client.get("/health")
+        assert "X-XSS-Protection" not in response.headers
 
     def test_referrer_policy(self, client):
         response = client.get("/health")
@@ -105,5 +129,8 @@ class TestPipelineErrorSanitization:
                             headers={"X-Pipeline-Key": "dev-key"},
                         )
                         assert response.status_code == 500
-                        assert "secret123" not in response.json()["detail"]
-                        assert response.json()["detail"] == "Pipeline execution failed"
+                        body = response.json()
+                        detail = body["detail"]
+                        assert "secret123" not in str(detail)
+                        assert detail["detail"] == "Pipeline execution failed"
+                        assert detail["code"] == "PIPELINE_FAILED"

--- a/workflows/compare_workflow.py
+++ b/workflows/compare_workflow.py
@@ -49,7 +49,7 @@ class CompareState(TypedDict):
 
 async def search_sources_node(state: CompareState) -> dict:
     """Search each source in parallel using Claude web_search."""
-    client = anthropic.AsyncAnthropic(api_key=settings.anthropic_api_key)
+    client = anthropic.AsyncAnthropic(api_key=settings.anthropic_api_key, max_retries=2)
     topic = _sanitize_text(state["topic"])
     # Validate sources against allowlist; reject unknown names
     sources = [
@@ -146,7 +146,7 @@ async def extract_and_compare_node(state: CompareState) -> dict:
             "claims": [],
         }
 
-    client = anthropic.AsyncAnthropic(api_key=settings.anthropic_api_key)
+    client = anthropic.AsyncAnthropic(api_key=settings.anthropic_api_key, max_retries=2)
 
     # Format source texts for the prompt
     source_texts = ""

--- a/workflows/pipeline_workflow.py
+++ b/workflows/pipeline_workflow.py
@@ -169,10 +169,6 @@ async def store_node(state: PipelineState) -> dict:
             errors=0,
         )
 
-    # Attribute total skipped count to "top" as a summary figure
-    if total_skipped > 0:
-        results["top"].skipped = total_skipped
-
     # Upsert each new article
     stored = 0
     for article in new_articles:
@@ -239,7 +235,7 @@ async def store_node(state: PipelineState) -> dict:
             logger.error("Failed to update pipeline_state for %s: %s", cat, e)
 
     logger.info("store: inserted %d articles", stored)
-    return {"results": results}
+    return {"results": results, "total_skipped": total_skipped}
 
 
 # --- Build the graph ---


### PR DESCRIPTION
## Summary

Comprehensive review of the Sift API from UI/UX, compatibility, accessibility, design, product, branding, and professional/sellable perspectives. Found and fixed **22 issues** across 13 files (+1 new).

### Critical Fixes
- **README accuracy**: Fix wrong embedding dimensions (1024→512), add missing auth header in compare example
- **Health endpoint honesty**: Return `"degraded"` when DB is unavailable instead of false `"healthy"`
- **Type safety**: Fix `CompareResponse.claims` from `list[dict]` to `list[Claim]` (model already existed but wasn't used)
- **Version consistency**: Align User-Agent (`Sift/1.0`) and API version (`1.0.0`) — were mismatched as `Sift/2.0` and `0.1.0`
- **Pipeline accuracy**: Fix misleading skipped count (was dumped into "top" category) → new top-level `total_skipped` field

### Professional Polish
- **OpenAPI docs**: Add descriptions to all endpoints and FastAPI app (Swagger UI at `/docs` now looks professional)
- **Request tracing**: `X-Request-ID` header generated or echoed on every response
- **API versioning**: Dual-mount approach — `/v1/pipeline/refresh` preferred, legacy paths preserved (non-breaking)
- **Structured errors**: Error codes (`PIPELINE_FAILED`, `COMPARISON_FAILED`, `NO_COVERAGE`, `COMPARISON_TIMEOUT`)
- **Modern security headers**: CSP + Permissions-Policy replace deprecated X-XSS-Protection
- **Content-Language**: `en` header for accessibility
- **Root endpoint**: Now includes links to `/docs` and `/redoc`

### Compatibility & Robustness
- **Retry logic**: `max_retries=2` on all Anthropic API clients
- **Compare timeout**: 90-second top-level timeout with proper 504 response
- **Shared limiter**: Consolidate 3 duplicate `Limiter` instances into `app/dependencies.py`
- **TODO comments**: Document planned features (custom_topics, bookmarks, from_search) in `init.sql`

### Tests Updated
- 7 new security header tests (CSP, Permissions-Policy, Content-Language, request ID, deprecated XSS removal)
- Updated error sanitization tests for structured error format
- Updated health test for degraded status semantics

## Test plan
- [ ] `ruff check .` passes (verified)
- [ ] `pytest tests/ -v` passes (verified for importable tests; DB-dependent tests require asyncpg)
- [ ] `GET /` returns version 1.0.0 and docs links
- [ ] `GET /health` returns `"degraded"` when DB is unavailable
- [ ] `GET /docs` renders OpenAPI descriptions
- [ ] Response headers include `X-Request-ID`, `Content-Security-Policy`, `Permissions-Policy`, `Content-Language`
- [ ] `X-XSS-Protection` header is no longer present
- [ ] `/v1/pipeline/refresh` and `/pipeline/refresh` both work
- [ ] Error responses include `code` field for programmatic handling