### PR TITLE
Fix pipeline crash: add missing total_skipped to PipelineState

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -39,6 +39,7 @@ async def _scheduled_refresh():
                 "summaries": {},
                 "embeddings": {},
                 "results": {},
+                "total_skipped": 0,
                 "errors": [],
             }
             result = await pl.ainvoke(initial_state)

--- a/app/routers/pipeline.py
+++ b/app/routers/pipeline.py
@@ -46,6 +46,7 @@ async def refresh_pipeline(
         "summaries": {},
         "embeddings": {},
         "results": {},
+        "total_skipped": 0,
         "errors": [],
     }
 

--- a/workflows/pipeline_workflow.py
+++ b/workflows/pipeline_workflow.py
@@ -19,6 +19,7 @@ class PipelineState(TypedDict):
     summaries: dict[str, dict]       # source_url -> {"summary": str, "category": str}
     embeddings: dict[str, list[float]]  # source_url -> vector
     results: dict[str, CategoryResult]
+    total_skipped: int
     errors: list[str]
 
 


### PR DESCRIPTION
## Summary
- PR #5 moved `total_skipped` from `CategoryResult.skipped` to a separate return value from `store_node`, but never added it to the `PipelineState` TypedDict
- LangGraph rejects unknown keys in state updates, so the pipeline crashes on every refresh — both manual and the scheduled 10-minute background job
- Added `total_skipped: int` to `PipelineState` and `total_skipped: 0` to both initial state dicts (router + scheduled refresh)

## Test plan
- [ ] Trigger a manual pipeline refresh via `POST /v1/pipeline/refresh` and confirm it completes without error
- [ ] Verify the response includes `total_skipped` with the correct count
- [ ] Confirm the scheduled background refresh logs success instead of errors