### PR TITLE
Fix article categorization and filter insufficient content

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -102,9 +102,9 @@ CREATE TABLE IF NOT EXISTS pipeline_state (
     error TEXT
 );
 
--- Seed pipeline_state with all 10 categories
+-- Seed pipeline_state with all 11 categories
 INSERT INTO pipeline_state (category) VALUES
     ('top'), ('technology'), ('business'), ('science'),
     ('energy'), ('world'), ('health'), ('politics'),
-    ('sports'), ('entertainment')
+    ('sports'), ('entertainment'), ('fashion')
 ON CONFLICT (category) DO NOTHING;

--- a/scripts/cleanup_insufficient_content.py
+++ b/scripts/cleanup_insufficient_content.py
@@ -1,0 +1,76 @@
+"""
+One-shot script to remove existing articles whose summaries indicate
+insufficient content (e.g. "insufficient content to evaluate",
+"unable to provide a summary", etc.).
+
+Run from sift-api root:  python scripts/cleanup_insufficient_content.py
+
+Optionally pass DATABASE_URL as env var to target a different database.
+Set DRY_RUN=1 to preview what would be deleted without making changes.
+"""
+import asyncio
+import os
+import sys
+
+# Add parent dir to path so imports work
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import asyncpg
+from app.config import settings
+from services.summarizer import _INSUFFICIENT_CONTENT_PHRASES
+
+
+async def main():
+    dry_run = os.environ.get("DRY_RUN", "").strip() in ("1", "true", "yes")
+    db_url = os.environ.get("DATABASE_URL", settings.database_url)
+    ssl_mode = "require" if "neon.tech" in db_url else False
+    pool = await asyncpg.create_pool(db_url, min_size=1, max_size=5, ssl=ssl_mode)
+
+    # Build WHERE clause matching any of the insufficient-content phrases
+    conditions = " OR ".join(
+        f"LOWER(summary) LIKE '%{phrase}%'" for phrase in _INSUFFICIENT_CONTENT_PHRASES
+    )
+    # Also catch the exact marker the updated prompt now emits
+    conditions += " OR LOWER(summary) = 'insufficient_content'"
+    # Also catch empty/null summaries
+    conditions = f"({conditions}) OR summary IS NULL OR TRIM(summary) = ''"
+
+    query = f"SELECT id, title, summary, source_url FROM articles WHERE {conditions}"
+    rows = await pool.fetch(query)
+
+    if not rows:
+        print("No articles with insufficient content found. Database is clean.")
+        await pool.close()
+        return
+
+    print(f"Found {len(rows)} article(s) with insufficient content:\n")
+    for row in rows:
+        summary_preview = (row["summary"] or "(null)")[:80]
+        print(f"  - {row['title'][:60]}")
+        print(f"    Summary: {summary_preview}")
+        print(f"    URL: {row['source_url']}\n")
+
+    if dry_run:
+        print("DRY_RUN is set — no changes made.")
+        await pool.close()
+        return
+
+    # First detach from any stories (clear story_id reference)
+    article_ids = [row["id"] for row in rows]
+    await pool.execute(
+        "UPDATE articles SET story_id = NULL WHERE id = ANY($1::text[])",
+        article_ids,
+    )
+
+    # Delete the articles
+    deleted = await pool.execute(
+        "DELETE FROM articles WHERE id = ANY($1::text[])",
+        article_ids,
+    )
+
+    print(f"Deleted {len(article_ids)} articles. ({deleted})")
+    await pool.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/services/summarizer.py
+++ b/services/summarizer.py
@@ -16,6 +16,21 @@ MODEL = "claude-haiku-4-5-20251001"
 
 VALID_CATEGORIES = {"top", "technology", "business", "science", "energy", "world", "health", "politics", "sports", "entertainment"}
 
+# Summaries matching these patterns indicate the AI could not meaningfully
+# evaluate the article content.  These articles should be excluded downstream.
+_INSUFFICIENT_CONTENT_PHRASES = [
+    "insufficient content",
+    "unable to provide",
+    "unable to summarize",
+    "not enough information",
+    "not enough content",
+    "cannot be summarized",
+    "no content available",
+    "content unavailable",
+    "content not available",
+    "cannot determine",
+]
+
 
 async def summarize_articles(articles: list[RSSArticle]) -> dict[str, dict]:
     """
@@ -80,19 +95,25 @@ def _build_prompt(batch: list[RSSArticle]) -> str:
 
     return f"""Summarize each of the following news articles in 1-2 concise sentences. Focus on the key facts and why the story matters.
 
-Also classify each article into exactly ONE category:
+If there is not enough content to write a meaningful summary, return the summary as exactly "INSUFFICIENT_CONTENT" (this exact string, nothing else).
+
+Also classify each article into exactly ONE of these categories (no other categories are allowed):
 - "top" — only for major breaking news or cross-cutting stories that transcend a single topic
 - "technology" — tech industry, software, hardware, AI, cybersecurity, social media
-- "business" — Wall Street, stock market, earnings reports, M&A, IPOs, venture capital, interest rates, Federal Reserve, banking, employment data, GDP, inflation, corporate strategy, trade policy. NOT consumer product launches, pop culture brands, or retail sales events
+- "business" — Wall Street, stock market, earnings reports, M&A, IPOs, venture capital, interest rates, Federal Reserve, banking, employment data, GDP, inflation, corporate strategy, trade policy, tariffs, markets. NOT consumer product launches, pop culture brands, or retail sales events
 - "science" — research, discoveries, space, physics, biology, climate science
 - "energy" — power grid, renewables, oil & gas, EVs, energy policy, utilities
 - "world" — international affairs, geopolitics, diplomacy, foreign policy
 - "health" — medicine, public health, pharma, healthcare policy, disease
-- "politics" — elections, legislation, political parties, Congress, campaigns, government policy
+- "politics" — elections, legislation, political parties, Congress, campaigns, government policy, political satire, Capitol Hill commentary, political columns
 - "sports" — professional sports, college sports, Olympics, player trades, game results
 - "entertainment" — movies, TV, music, celebrities, streaming, awards, pop culture, consumer product launches, brand collaborations, viral consumer trends
 
-Most articles should go into a specific topic category. Only use "top" for truly major stories.
+IMPORTANT classification rules:
+- Use the source name as a strong signal. For example, Roll Call, Politico, The Hill are political sources — articles from them are almost always "politics" or "business", never lifestyle categories.
+- You MUST only return one of the 10 categories listed above. Do NOT invent new categories like "fashion", "lifestyle", "food", etc.
+- Most articles should go into a specific topic category. Only use "top" for truly major stories.
+- When article content is thin, rely on the source name and title to choose the best category.
 
 {articles_text}
 
@@ -169,6 +190,19 @@ def _extract_json_array(text: str) -> list[dict] | None:
             return items
 
     return None
+
+
+def is_insufficient_content(summary: str) -> bool:
+    """Return True if the summary indicates the AI could not meaningfully evaluate the article."""
+    if not summary:
+        return True
+    lower = summary.lower().strip()
+    if lower == "insufficient_content":
+        return True
+    for phrase in _INSUFFICIENT_CONTENT_PHRASES:
+        if phrase in lower:
+            return True
+    return False
 
 
 def _truncate(text: str, max_words: int) -> str:

--- a/services/summarizer.py
+++ b/services/summarizer.py
@@ -14,7 +14,7 @@ logger = logging.getLogger("sift-api.summarizer")
 BATCH_SIZE = 5
 MODEL = "claude-haiku-4-5-20251001"
 
-VALID_CATEGORIES = {"top", "technology", "business", "science", "energy", "world", "health", "politics", "sports", "entertainment"}
+VALID_CATEGORIES = {"top", "technology", "business", "science", "energy", "world", "health", "politics", "sports", "entertainment", "fashion"}
 
 # Summaries matching these patterns indicate the AI could not meaningfully
 # evaluate the article content.  These articles should be excluded downstream.
@@ -108,12 +108,14 @@ Also classify each article into exactly ONE of these categories (no other catego
 - "politics" — elections, legislation, political parties, Congress, campaigns, government policy, political satire, Capitol Hill commentary, political columns
 - "sports" — professional sports, college sports, Olympics, player trades, game results
 - "entertainment" — movies, TV, music, celebrities, streaming, awards, pop culture, consumer product launches, brand collaborations, viral consumer trends
+- "fashion" — fashion industry, clothing, runway shows, designer brands, style trends, fashion weeks, luxury goods, apparel companies, beauty industry
 
 IMPORTANT classification rules:
-- Use the source name as a strong signal. For example, Roll Call, Politico, The Hill are political sources — articles from them are almost always "politics" or "business", never lifestyle categories.
-- You MUST only return one of the 10 categories listed above. Do NOT invent new categories like "fashion", "lifestyle", "food", etc.
+- Use the source name as a strong signal. For example, Roll Call, Politico, The Hill are political sources — articles from them are almost always "politics" or "business", never "fashion" or other lifestyle categories.
+- You MUST only return one of the 11 categories listed above. Do NOT invent new categories.
 - Most articles should go into a specific topic category. Only use "top" for truly major stories.
 - When article content is thin, rely on the source name and title to choose the best category.
+- "fashion" is ONLY for articles genuinely about the fashion/clothing/beauty industry. Political articles that mention markets, brands, or shopping metaphors are NOT fashion.
 
 {articles_text}
 

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -7,6 +7,7 @@ from services.summarizer import (
     _build_prompt,
     _parse_summaries,
     _truncate,
+    is_insufficient_content,
 )
 from app.models import RSSArticle
 
@@ -110,6 +111,28 @@ class TestBuildPrompt:
         assert "<p>" not in prompt
         assert "<b>" not in prompt
         assert "Hello world" in prompt
+
+
+class TestIsInsufficientContent:
+    def test_exact_marker(self):
+        assert is_insufficient_content("INSUFFICIENT_CONTENT") is True
+
+    def test_phrase_match(self):
+        assert is_insufficient_content("Insufficient content to evaluate this article.") is True
+        assert is_insufficient_content("Unable to provide a summary due to limited text.") is True
+        assert is_insufficient_content("Cannot determine the topic of this article.") is True
+
+    def test_empty_and_none(self):
+        assert is_insufficient_content("") is True
+        assert is_insufficient_content(None) is True
+
+    def test_valid_summary(self):
+        assert is_insufficient_content("Congress passed a new spending bill today.") is False
+        assert is_insufficient_content("The stock market rose 2% on strong earnings reports.") is False
+
+    def test_case_insensitive(self):
+        assert is_insufficient_content("UNABLE TO PROVIDE a summary") is True
+        assert is_insufficient_content("Insufficient Content to evaluate") is True
 
 
 class TestTruncate:

--- a/workflows/pipeline_workflow.py
+++ b/workflows/pipeline_workflow.py
@@ -9,7 +9,7 @@ from app.models import RSSArticle, CategoryResult
 
 logger = logging.getLogger("sift-api.pipeline")
 
-ALL_CATEGORIES = ["top", "technology", "business", "science", "energy", "world", "health", "politics", "sports", "entertainment"]
+ALL_CATEGORIES = ["top", "technology", "business", "science", "energy", "world", "health", "politics", "sports", "entertainment", "fashion"]
 
 
 class PipelineState(TypedDict):

--- a/workflows/pipeline_workflow.py
+++ b/workflows/pipeline_workflow.py
@@ -67,7 +67,7 @@ async def deduplicate_node(state: PipelineState) -> dict:
 
 async def summarize_node(state: PipelineState) -> dict:
     """Batch-summarize and classify new articles using Claude Haiku."""
-    from services.summarizer import summarize_articles
+    from services.summarizer import summarize_articles, is_insufficient_content
 
     new_articles = state.get("new_articles", [])
     if not new_articles:
@@ -78,15 +78,34 @@ async def summarize_node(state: PipelineState) -> dict:
         summaries = await summarize_articles(new_articles)
         logger.info("summarize: generated %d summaries with categories", len(summaries))
 
-        # Apply AI-assigned categories back to each article
+        # Filter out articles whose summaries indicate insufficient content
+        filtered_articles = []
+        filtered_summaries: dict[str, dict] = {}
+        skipped_insufficient = 0
+
         for article in new_articles:
             result = summaries.get(article.source_url)
+            if result and is_insufficient_content(result["summary"]):
+                skipped_insufficient += 1
+                logger.info(
+                    "summarize: skipping article with insufficient content: %s",
+                    article.source_url,
+                )
+                continue
             if result:
                 article.category = result["category"]
+                filtered_summaries[article.source_url] = result
             else:
                 article.category = "top"  # fallback
+            filtered_articles.append(article)
 
-        return {"summaries": summaries, "new_articles": new_articles}
+        if skipped_insufficient:
+            logger.info(
+                "summarize: filtered out %d articles with insufficient content",
+                skipped_insufficient,
+            )
+
+        return {"summaries": filtered_summaries, "new_articles": filtered_articles}
     except Exception as e:
         logger.error("summarize failed: %s", e)
         # Fall back to raw RSS content as summaries, default to "top" category


### PR DESCRIPTION
## Summary
- **Fix miscategorization**: Articles from political sources (Roll Call, Politico, The Hill) were being classified into wrong categories. Updated the AI prompt to use source name as a strong classification signal and added guardrails against misclassification.
- **Add fashion category**: Added "fashion" as a valid backend category to match the custom UI category, with a clear definition so the AI knows what belongs there vs. politics/business.
- **Filter insufficient content**: Articles where the AI summary indicates it couldn't evaluate the content (e.g. "insufficient content to evaluate") are now filtered out before being stored in the database.
- **Cleanup script**: Added `scripts/cleanup_insufficient_content.py` to remove existing insufficient-content articles already in the DB. Supports `DRY_RUN=1` to preview before deleting.

## Test plan
- [x] All 20 summarizer tests pass (including 5 new tests for `is_insufficient_content`)
- [ ] Run `DRY_RUN=1 python scripts/cleanup_insufficient_content.py` against production DB to verify matches
- [ ] After deploy, verify Roll Call articles are categorized as "politics" or "business"
- [ ] Verify articles with thin RSS content no longer appear with "insufficient content" summaries