### PR TITLE
Add partial indexes for /api/news feed queries

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -49,6 +49,34 @@ async def _apply_migrations(pool: asyncpg.Pool) -> None:
             "ON api_batches(status, kind)"
         )
 
+        # Feed indexes (migrations/004_feed_indexes.sql). Partial indexes that
+        # match the exact predicates in sift/lib/db.ts's user-facing queries,
+        # so category feeds don't fall back to sequential scans on articles.
+        # CREATE INDEX (without CONCURRENTLY) is fine here: asyncpg runs each
+        # execute() in autocommit, and IF NOT EXISTS makes repeat deploys a
+        # no-op. CONCURRENTLY lives in the SQL file for operators who prefer
+        # to apply the migration manually against a live DB.
+        await conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_articles_feed "
+            "ON articles (category, published_date DESC) "
+            "WHERE from_search = false "
+            "AND summary IS NOT NULL "
+            "AND summary <> ''"
+        )
+        await conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_articles_story_feed "
+            "ON articles (story_id) "
+            "WHERE story_id IS NOT NULL "
+            "AND from_search = false "
+            "AND summary IS NOT NULL "
+            "AND summary <> ''"
+        )
+        await conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_stories_feed "
+            "ON stories (category, published_date DESC) "
+            "WHERE synthesis_status = 'complete'"
+        )
+
 
 async def get_pool() -> asyncpg.Pool:
     if _pool is None:

--- a/migrations/004_feed_indexes.sql
+++ b/migrations/004_feed_indexes.sql
@@ -1,0 +1,40 @@
+-- 004_feed_indexes.sql
+--
+-- Partial indexes that match the exact predicates used by the user-facing
+-- `/api/news?category=...` queries in sift/lib/db.ts. Without these, the
+-- planner reverts to sequential scans on `articles` (filtered by
+-- from_search + summary quality), which pushes business/sports past the
+-- 10s client-side abort (API_TIMEOUT_MS in sift/lib/constants.ts).
+--
+-- CONCURRENTLY lets us add these on a live production DB without blocking
+-- writes. IF NOT EXISTS keeps the file idempotent for re-runs.
+--
+-- NOTE: CREATE INDEX CONCURRENTLY cannot run inside a transaction block.
+-- Apply this file with `psql -f` (one statement at a time, autocommit),
+-- NOT wrapped in BEGIN/COMMIT.
+
+-- 1. Feed-quality articles by category + recency.
+--    Serves getArticlesByCategory (lib/db.ts:36) and the standalone-articles
+--    query in getStoriesWithArticles (lib/db.ts:150).
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_articles_feed
+    ON articles (category, published_date DESC)
+    WHERE from_search = false
+      AND summary IS NOT NULL
+      AND summary <> '';
+
+-- 2. Feed-quality articles by story_id.
+--    Serves the LEFT JOIN in the stories query (lib/db.ts:85) and the
+--    `story_id = ANY($1)` fetch (lib/db.ts:121).
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_articles_story_feed
+    ON articles (story_id)
+    WHERE story_id IS NOT NULL
+      AND from_search = false
+      AND summary IS NOT NULL
+      AND summary <> '';
+
+-- 3. Complete stories by category + recency.
+--    Serves the outer filter in getStoriesWithArticles (lib/db.ts:85).
+--    Narrows to rows the UI actually renders (synthesis_status = 'complete').
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_stories_feed
+    ON stories (category, published_date DESC)
+    WHERE synthesis_status = 'complete';


### PR DESCRIPTION
## Summary

Fixes the 10s client-side timeout (\"We hit a snag pulling today's stories / Request timed out\") that users hit on category tabs — most visibly on **business** and **sports**.

## Root cause

`/api/news?category=<cat>` is served by `getStoriesWithArticles` and `getArticlesByCategory` in `sift/lib/db.ts`. Those queries filter articles by `category`, `from_search = false`, and `summary IS NOT NULL AND summary <> ''`. The existing indexes (`idx_articles_category_date`, `idx_articles_story_id`) don't carry those partial predicates, so the planner scans the full category set and then re-filters, blowing past the 10s `API_TIMEOUT_MS` in `sift/lib/constants.ts` on the heaviest categories.

## Change

Three partial indexes tuned to the exact predicates used on the critical path:

| Index | Table / columns | Partial `WHERE` | Serves |
|---|---|---|---|
| `idx_articles_feed` | `articles (category, published_date DESC)` | `from_search=false AND summary IS NOT NULL AND summary <> ''` | `getArticlesByCategory` + standalone-articles query |
| `idx_articles_story_feed` | `articles (story_id)` | same quality predicates + `story_id IS NOT NULL` | LEFT JOIN + `story_id = ANY($1)` |
| `idx_stories_feed` | `stories (category, published_date DESC)` | `synthesis_status = 'complete'` | outer stories filter |

Applied idempotently at FastAPI startup via `_apply_migrations` in `app/db.py` (matches the existing pattern used for `idx_articles_content_hash` / `idx_api_batches_status_kind`). `migrations/004_feed_indexes.sql` contains the `CONCURRENTLY` variant for operators who prefer to apply it manually against a live DB.

No query rewrites, no pool/timeout changes, no frontend edits. Rolling back is a `DROP INDEX IF EXISTS` on the three names — purely additive.

## Test plan

- [ ] Before deploy: `EXPLAIN (ANALYZE, BUFFERS)` the stories + standalone-articles queries for `category='business'` and `category='sports'`; capture baseline runtime + note `Seq Scan` nodes.
- [ ] Deploy to Railway (auto-runs `_apply_migrations` at startup).
- [ ] Verify: `psql \"\\$DATABASE_URL\" -c \"\\d+ articles\"` shows `idx_articles_feed` and `idx_articles_story_feed` with their partial predicates; `\\d+ stories` shows `idx_stories_feed`.
- [ ] Re-run the EXPLAIN ANALYZE — expect `Index Scan` on the new indexes, wall-clock well under 1.5s.
- [ ] Smoke-test UI: load \`/\` and click through all 10 tabs (top, technology, business, science, energy, world, health, politics, sports, entertainment). No \"Request timed out\" errors; `/api/news?category=<cat>` stays under 10s in DevTools Network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)