### PR TITLE
Wire explain_feed_queries.py into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,47 @@ jobs:
 
       - name: Test
         run: pytest tests/ -v
+
+  feed-perf:
+    name: Feed Query Perf
+    # Only runs when a PR touches the query surface or the diagnostic script.
+    # Guards against plan regressions landing in main without being noticed.
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Need enough history to diff against the PR base.
+          fetch-depth: 0
+
+      - name: Detect relevant changes
+        id: changes
+        run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+          if git diff --name-only "$base" "$head" -- \
+              app/db.py \
+              migrations \
+              scripts/explain_feed_queries.py \
+              | grep -q .; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/setup-python@v5
+        if: steps.changes.outputs.run == 'true'
+        with:
+          python-version-file: '.python-version'
+          cache: 'pip'
+
+      - name: Install deps
+        if: steps.changes.outputs.run == 'true'
+        run: pip install -r requirements.txt
+
+      - name: EXPLAIN ANALYZE feed queries
+        if: steps.changes.outputs.run == 'true'
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: python scripts/explain_feed_queries.py


### PR DESCRIPTION
## Summary
- Add `feed-perf` job to `.github/workflows/ci.yml` that runs `scripts/explain_feed_queries.py` on PRs touching `app/db.py`, `migrations/`, or the script itself.
- In-job git diff (rather than workflow `paths:` filter) so the check still reports a status on every PR — safe for required-status-check branch protection while staying cheap for unrelated PRs.
- Uses prod `DATABASE_URL` via a GitHub repo secret. Script already exits non-zero on FAIL (>= 8000 ms), so plan regressions naturally fail the job.

## Setup required before merge
Add `DATABASE_URL` as a repo secret (Settings → Secrets and variables → Actions → New repository secret), set to the same prod Postgres URL the Railway service uses.

Without the secret the job will run but the script will fail at connection time — that's the correct loud failure to notice the missing config.

## Test plan
- [ ] Add `DATABASE_URL` repo secret
- [ ] Verify `lint-test` still passes on this PR
- [ ] Verify `feed-perf` is skipped on this PR (no changes to `app/db.py` / `migrations/` / the script itself — only the workflow file)
- [ ] Open a follow-up no-op PR that touches one of the trigger paths (e.g. a comment in `app/db.py`) to confirm `feed-perf` runs and passes on current indexes

🤖 Generated with [Claude Code](https://claude.com/claude-code)