### PR TITLE
feed-perf: emit ::warning::/::error:: annotations so degradation surfaces on PR Checks

### DIFF
--- a/scripts/explain_feed_queries.py
+++ b/scripts/explain_feed_queries.py
@@ -171,6 +171,22 @@ async def run(verbose: bool) -> int:
                 idx_str = ", ".join(sorted(idx)) if idx else "(no index — seq scan)"
                 print(f"{cat:<14} {label:<11} {ms:>9.1f}  {idx_str:<50} {v}")
 
+                # Surface warns/fails on the GitHub Actions Checks tab so a
+                # slope of degradation is visible before it becomes a cliff.
+                # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions
+                if v == "WARN":
+                    print(
+                        f"::warning title=feed-perf {cat}/{label} slow"
+                        f"::{ms:.1f} ms (warn threshold {WARN_MS} ms). "
+                        f"See sift-api#16 for the deferred follow-ups."
+                    )
+                elif v == "FAIL":
+                    print(
+                        f"::error title=feed-perf {cat}/{label} failing"
+                        f"::{ms:.1f} ms (fail threshold {FAIL_MS} ms). "
+                        f"Pick from sift-api#16."
+                    )
+
                 if verbose:
                     print(json.dumps(plan, indent=2))
                     print()


### PR DESCRIPTION
## Summary

- Emit GitHub Actions \`::warning::\` annotation when a feed query lands in the WARN band (2000–7999 ms).
- Emit \`::error::\` annotation for FAIL (>= 8000 ms); CI exit code already fails for this case.
- Each annotation references #16 so when it fires it's obvious which deferred follow-up to pick from.

## What was actually missing

When I opened #17 I claimed \`WARN_MS\` didn't exist — re-reading \`scripts/explain_feed_queries.py\`, it's been there since #10 (line 38, integrated into \`verdict()\`, \`worst_verdict\` rollup, and the final summary line). The actual gap is that WARN status only printed to stdout, so a slope of degradation got buried in the CI log instead of surfacing on the Checks tab and PR conversation thread where humans actually look.

This change is the smaller, real fix: emit workflow commands so the WARN band is visible.

## Behavior

| Query time | Stdout line | Annotation | Job exit |
| --- | --- | --- | --- |
| < 2000 ms | \`ok\` | none | 0 |
| 2000–7999 ms | \`WARN\` | \`::warning::\` on Checks tab | 0 (preserved) |
| >= 8000 ms | \`FAIL\` | \`::error::\` on Checks tab | 1 (preserved) |

## Test plan

- [x] \`./.venv/bin/python3 scripts/explain_feed_queries.py --help\` parses cleanly.
- [ ] On this PR's \`feed-perf\` run: all queries should still land in \`ok\` (current prod baseline is 0.6–152 ms across all 30 queries). No annotations expected. Job stays green.
- [ ] Self-test (separate scratch PR, do not merge): inject \`pg_sleep(3)\` into one query, confirm \`::warning::\` annotation appears on the Checks tab and the job stays green.
- [ ] Same for FAIL with \`pg_sleep(10)\`.

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)