### PR TITLE
Civic-literacy MVP Phase 1A — context_primer pipeline

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -77,6 +77,17 @@ async def _apply_migrations(pool: asyncpg.Pool) -> None:
             "WHERE synthesis_status = 'complete'"
         )
 
+        # Civic-literacy MVP (migrations/005_context_primer_and_reading_levels.sql).
+        # context_primer holds the "What you should know first" panel data;
+        # reading_levels holds Claude rewrites at simpler + detailed reading
+        # levels for long-form articles. Both nullable — UI tolerates NULL.
+        await conn.execute(
+            "ALTER TABLE articles ADD COLUMN IF NOT EXISTS context_primer JSONB"
+        )
+        await conn.execute(
+            "ALTER TABLE articles ADD COLUMN IF NOT EXISTS reading_levels JSONB"
+        )
+
 
 async def get_pool() -> asyncpg.Pool:
     if _pool is None:

--- a/migrations/005_context_primer_and_reading_levels.sql
+++ b/migrations/005_context_primer_and_reading_levels.sql
@@ -1,0 +1,23 @@
+-- Context primer + reading levels for the civic-literacy MVP (Phase 1).
+--
+-- See plans/sift-civic-literacy.md for full context. Both columns are
+-- additive and nullable; existing rows get NULL until backfill (Phase 1A
+-- only ships primer; reading_levels arrives in Phase 1B).
+--
+-- context_primer  — "What you should know first" panel:
+--   { background: string,
+--     terms: [{ term: string, definition: string, source?: string }],
+--     generated_at: ISO8601 string }
+--
+-- reading_levels  — Claude rewrites of the article body for two non-default
+-- reading levels (simpler + detailed). Only populated for long-form articles
+-- (>~800 words); short wires render the standard summary at all levels.
+--   { simpler:  { headline: string, summary: string },
+--     detailed: { headline: string, summary: string },
+--     generated_at: ISO8601 string }
+--
+-- These are read by sift/lib/db.ts and rendered by the primer + reading-level
+-- slider components in sift/components/primer/.
+
+ALTER TABLE articles ADD COLUMN IF NOT EXISTS context_primer JSONB;
+ALTER TABLE articles ADD COLUMN IF NOT EXISTS reading_levels JSONB;

--- a/scripts/backfill_primers.py
+++ b/scripts/backfill_primers.py
@@ -1,0 +1,121 @@
+"""One-shot script to backfill articles.context_primer for existing rows.
+
+Run from sift-api root:
+    ./.venv/bin/python3 scripts/backfill_primers.py [--limit N]
+
+Optionally pass DATABASE_URL as an env var to target a different database.
+
+Defaults to the most recent 200 articles missing a primer (the figure cited
+in plans/sift-civic-literacy.md). Override with --limit to backfill more or
+fewer; pass --limit 0 to process every article missing a primer.
+
+Cost (rough): ~ $0.005 per article in Haiku tier × 200 = ~$1 for the default
+backfill. Live API path (not the batch API) so it completes synchronously.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+
+# Add parent dir to path so imports resolve
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import asyncpg
+
+from app.config import settings
+from services.primer_generator import generate_primers
+
+
+async def main(limit: int) -> None:
+    db_url = os.environ.get("DATABASE_URL", settings.database_url)
+    ssl_mode = "require" if "neon.tech" in db_url else False
+    pool = await asyncpg.create_pool(db_url, min_size=1, max_size=5, ssl=ssl_mode)
+
+    where_limit = f"LIMIT {limit}" if limit > 0 else ""
+
+    rows = await pool.fetch(
+        f"""
+        SELECT source_url, source_name, title, summary
+        FROM articles
+        WHERE context_primer IS NULL
+          AND summary IS NOT NULL
+          AND summary != ''
+          AND LOWER(summary) NOT LIKE 'unable to provide%'
+        ORDER BY published_date DESC NULLS LAST, created_at DESC
+        {where_limit}
+        """
+    )
+
+    if not rows:
+        print("No articles need primer backfilling.")
+        await pool.close()
+        return
+
+    print(f"Found {len(rows)} articles to backfill primers for...")
+
+    articles = [
+        {
+            "source_url": r["source_url"],
+            "source_name": r["source_name"],
+            "title": r["title"],
+            "summary": r["summary"],
+        }
+        for r in rows
+    ]
+
+    # Process in chunks so progress is visible and partial failures don't lose
+    # earlier work. CHUNK_SIZE * BATCH_SIZE in primer_generator = articles per
+    # API call burst.
+    CHUNK_SIZE = 50
+    total_updated = 0
+    total_skipped = 0  # primer came back empty (genuinely no context needed)
+    total_chunks = (len(articles) + CHUNK_SIZE - 1) // CHUNK_SIZE
+
+    for chunk_start in range(0, len(articles), CHUNK_SIZE):
+        chunk = articles[chunk_start : chunk_start + CHUNK_SIZE]
+        chunk_num = chunk_start // CHUNK_SIZE + 1
+        print(f"  Chunk {chunk_num}/{total_chunks} ({len(chunk)} articles)...")
+
+        results = await generate_primers(chunk)
+        print(f"    Generated {len(results)} primers, writing to DB...")
+
+        for source_url, primer in results.items():
+            try:
+                await pool.execute(
+                    "UPDATE articles SET context_primer = $1::jsonb, updated_at = NOW() "
+                    "WHERE source_url = $2",
+                    json.dumps(primer),
+                    source_url,
+                )
+                total_updated += 1
+            except Exception as e:
+                print(f"    UPDATE failed for {source_url}: {e}")
+
+        # Articles in the chunk for which the LLM returned no primer (because
+        # the article needed no civic context) — track but don't write.
+        chunk_urls = {a["source_url"] for a in chunk}
+        total_skipped += len(chunk_urls - results.keys())
+
+        print(f"    Progress: {total_updated} updated, {total_skipped} skipped (empty).")
+
+    print(
+        f"\nDone! Updated {total_updated} articles with context_primer; "
+        f"{total_skipped} returned empty (no primer needed)."
+    )
+
+    await pool.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Backfill context_primer for existing articles.")
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=200,
+        help="Max articles to process. 0 = no limit. Default: 200 (per civic-literacy plan).",
+    )
+    args = parser.parse_args()
+    asyncio.run(main(limit=args.limit))

--- a/services/batch_poller.py
+++ b/services/batch_poller.py
@@ -18,6 +18,10 @@ from services.entity_extractor import (
     BATCH_KIND as ENTITY_BATCH_KIND,
     process_entity_batch_results,
 )
+from services.primer_generator import (
+    BATCH_KIND as PRIMER_BATCH_KIND,
+    process_primer_batch_results,
+)
 
 logger = logging.getLogger("sift-api.batch_poller")
 
@@ -28,6 +32,7 @@ POLL_INTERVAL_SECONDS = 60
 HANDLERS = {
     CONTEXT_BATCH_KIND: process_context_batch_results,
     ENTITY_BATCH_KIND: process_entity_batch_results,
+    PRIMER_BATCH_KIND: process_primer_batch_results,
 }
 
 

--- a/services/primer_generator.py
+++ b/services/primer_generator.py
@@ -1,0 +1,330 @@
+"""Background-primer generator — Phase 1A of the civic-literacy MVP.
+
+For each article, generates a "What you should know first" panel:
+- background: one short paragraph of context the reader needs before the lede
+- terms: 3-5 key terms surfaced from the article body, each with a brief
+  plain-language definition
+
+The output lives at articles.context_primer (JSONB) and is rendered by the
+sift/components/primer/BackgroundPrimer.tsx component.
+
+Runs via Anthropic's Message Batches API for the 50% discount, mirroring the
+context_generator + entity_extractor patterns. Pipeline submits batches and
+returns immediately; the batch_poller invokes process_primer_batch_results
+when batches complete (typically within minutes).
+
+Voice: the patient teacher who never makes you feel dumb. Authoritative,
+never preachy, never partisan, never editorializing. See lib/copy.ts in
+the sift frontend for the full voice doc.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+
+import anthropic
+
+from app.config import settings
+from app.db import get_pool
+from services.batch_client import submit_batch
+from services.usage_tracker import log_usage
+
+logger = logging.getLogger("sift-api.primer_generator")
+
+MODEL = "claude-haiku-4-5-20251001"
+BATCH_SIZE = 5  # primer is more tokens out per article than one-liner context
+
+BATCH_KIND = "primer"  # identifier persisted to api_batches.kind
+
+# Voice/format guard. Keep prompt-engineering tight: the LLM gets one job per
+# article (write a primer + 3-5 terms) and outputs strict JSON. The prompt is
+# the same in both the live and batch paths.
+_PROMPT_HEADER = """You are writing the "What you should know first" panel for a civic-literacy news app. \
+For each article below, write a brief teaching primer for a smart American adult who may have missed key context.
+
+Two things per article:
+
+1. background — ONE short paragraph (max 60 words) of context the reader \
+needs before reading the article. Cover what's at stake, who the players are, or what came before — whichever \
+the reader most likely doesn't already know. Conversational tone. Active voice. Contractions OK. \
+NEVER editorialize, NEVER take a political side, NEVER tell the reader what to think.
+
+2. terms — 3 to 5 key terms from the article that benefit from a one-sentence plain-language definition. \
+Pick terms a non-expert would stumble on (filibuster, cloture, basis points, antitrust review, FOMC, \
+attainment standards, EBITDA, etc.) — NOT proper nouns or common words. Each term gets a max-25-word \
+definition that an 8th-grader could understand.
+
+Critical rules:
+- Never use the word "context" in the primer itself.
+- Never start with "This article is about" or similar meta-language.
+- Never recommend a position or imply one is correct.
+- If the article is short or self-contained and needs no context, return background as an empty string \
+and terms as an empty array. The UI hides empty primers.
+
+Articles:
+{articles_text}
+
+Return a JSON array with one object per article, in the same order. Use short keys to save tokens:
+i = index (1-based)
+b = background paragraph (string, may be empty)
+t = terms array (each term: {{"term": "...", "def": "..."}})
+
+[{{"i":1,"b":"Background paragraph here.","t":[{{"term":"filibuster","def":"A Senate procedure that requires 60 votes to end debate on most legislation."}}]}}, ...]
+
+Return ONLY the JSON array, no other text."""
+
+
+def _build_articles_text(batch: list[dict]) -> str:
+    text = ""
+    for i, article in enumerate(batch, 1):
+        text += (
+            f"\n{i}. \"{article['title']}\"\n"
+            f"   Source: {article.get('source_name', 'unknown')}\n"
+            f"   Summary: {article['summary']}\n"
+        )
+    return text
+
+
+def _build_prompt(batch: list[dict]) -> str:
+    return _PROMPT_HEADER.format(articles_text=_build_articles_text(batch))
+
+
+# ---------------------------------------------------------------------------
+# Live path (used for backfill and as a manual fallback)
+# ---------------------------------------------------------------------------
+
+async def generate_primers(articles: list[dict]) -> dict[str, dict]:
+    """Generate primers for a list of articles via the live Messages API.
+
+    Input: list of dicts with keys: source_url, title, summary, source_name (optional)
+    Output: dict mapping source_url -> { background, terms, generated_at }
+
+    For routine ingest, prefer submit_primer_batch (50% cheaper). This live path
+    exists for backfill scripts and one-off jobs where async batch latency is
+    unacceptable.
+    """
+    if not articles:
+        return {}
+
+    client = anthropic.AsyncAnthropic(api_key=settings.anthropic_api_key, max_retries=2)
+    results: dict[str, dict] = {}
+
+    for i in range(0, len(articles), BATCH_SIZE):
+        batch = articles[i : i + BATCH_SIZE]
+        try:
+            batch_results = await _generate_batch_live(client, batch)
+            results.update(batch_results)
+        except Exception as e:
+            logger.error("Primer generation failed for batch %d: %s", i // BATCH_SIZE, e)
+
+    logger.info("Generated primers for %d/%d articles", len(results), len(articles))
+    return results
+
+
+async def _generate_batch_live(
+    client: anthropic.AsyncAnthropic,
+    batch: list[dict],
+) -> dict[str, dict]:
+    response = await client.messages.create(
+        model=MODEL,
+        max_tokens=1500,  # ~300 tokens per article * 5 articles + headroom
+        messages=[{"role": "user", "content": _build_prompt(batch)}],
+    )
+    log_usage("primer_generator.batch", response, model=MODEL)
+
+    text = "".join(b.text for b in response.content if b.type == "text")
+    return _parse_primers(text, batch)
+
+
+def _parse_primers(text: str, batch: list[dict]) -> dict[str, dict]:
+    """Parse Claude's primer JSON response into the canonical persisted shape."""
+    results: dict[str, dict] = {}
+
+    parsed = _extract_json_array(text)
+    if not parsed:
+        logger.warning("Failed to parse primer generation JSON")
+        return results
+
+    now_iso = datetime.now(timezone.utc).isoformat()
+    for item in parsed:
+        idx = item.get("i", item.get("index"))
+        background = item.get("b", item.get("background", "")) or ""
+        terms_raw = item.get("t", item.get("terms", [])) or []
+
+        if not (isinstance(idx, int) and 1 <= idx <= len(batch)):
+            continue
+
+        # Normalize terms to a stable shape. Tolerate `def`/`definition` and
+        # drop any malformed entries silently.
+        terms: list[dict] = []
+        if isinstance(terms_raw, list):
+            for t in terms_raw:
+                if not isinstance(t, dict):
+                    continue
+                term = (t.get("term") or "").strip()
+                definition = (t.get("def") or t.get("definition") or "").strip()
+                if term and definition:
+                    terms.append({"term": term, "definition": definition})
+
+        # Skip articles that came back fully empty — UI handles NULL too, no
+        # need to write an empty record.
+        if not background and not terms:
+            continue
+
+        results[batch[idx - 1]["source_url"]] = {
+            "background": background.strip(),
+            "terms": terms,
+            "generated_at": now_iso,
+        }
+
+    return results
+
+
+def _extract_json_array(text: str) -> list[dict] | None:
+    """Extract a JSON array from LLM output, tolerating leading/trailing prose."""
+    text = text.strip()
+
+    try:
+        data = json.loads(text)
+        if isinstance(data, list):
+            return data
+    except json.JSONDecodeError:
+        pass
+
+    start = text.find("[")
+    end = text.rfind("]")
+    if start != -1 and end != -1 and end > start:
+        try:
+            data = json.loads(text[start : end + 1])
+            if isinstance(data, list):
+                return data
+        except json.JSONDecodeError:
+            pass
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Batch API path — same prompt, submitted via Message Batches for 50% discount.
+# ---------------------------------------------------------------------------
+
+async def submit_primer_batch(articles: list[dict]) -> str | None:
+    """Submit primer generation via Message Batches API.
+
+    articles: list of {source_url, title, summary, source_name (optional)}.
+    Each sub-batch of BATCH_SIZE articles becomes one request with
+    custom_id = "primer-<index>" so the result handler can map back.
+
+    Returns the batch_id (or None if submission failed / no input).
+    """
+    if not articles:
+        return None
+
+    requests: list[dict] = []
+    for i in range(0, len(articles), BATCH_SIZE):
+        sub = articles[i : i + BATCH_SIZE]
+        custom_id = f"primer-{i // BATCH_SIZE}"
+        requests.append({
+            "custom_id": custom_id,
+            "params": {
+                "model": MODEL,
+                "max_tokens": 1500,
+                "messages": [{"role": "user", "content": _build_prompt(sub)}],
+            },
+        })
+
+    metadata = {
+        f"primer-{i // BATCH_SIZE}": [a["source_url"] for a in articles[i : i + BATCH_SIZE]]
+        for i in range(0, len(articles), BATCH_SIZE)
+    }
+    return await submit_batch(BATCH_KIND, requests, metadata=metadata)
+
+
+async def process_primer_batch_results(batch_id: str, results: list[dict]) -> None:
+    """Poller callback. Parses JSONL results and UPDATEs articles.context_primer."""
+    pool = await get_pool()
+    row = await pool.fetchrow(
+        "SELECT metadata FROM api_batches WHERE batch_id = $1", batch_id,
+    )
+    if row is None:
+        logger.error("process_primer_batch_results: batch %s not in api_batches", batch_id)
+        return
+
+    raw_meta = row["metadata"]
+    if isinstance(raw_meta, str):
+        try:
+            raw_meta = json.loads(raw_meta)
+        except json.JSONDecodeError:
+            raw_meta = {}
+    custom_id_to_urls: dict[str, list[str]] = raw_meta or {}
+
+    updated = 0
+    failed = 0
+    for item in results:
+        custom_id = item.get("custom_id", "")
+        urls = custom_id_to_urls.get(custom_id, [])
+        result = item.get("result", {})
+        if result.get("type") != "succeeded":
+            failed += 1
+            continue
+
+        message = result.get("message", {})
+        content_blocks = message.get("content", []) or []
+        text = "".join(
+            b.get("text", "") for b in content_blocks if b.get("type") == "text"
+        )
+        parsed = _extract_json_array(text)
+        if not parsed:
+            failed += 1
+            continue
+
+        now_iso = datetime.now(timezone.utc).isoformat()
+        for entry in parsed:
+            idx = entry.get("i", entry.get("index"))
+            background = entry.get("b", entry.get("background", "")) or ""
+            terms_raw = entry.get("t", entry.get("terms", [])) or []
+
+            if not (isinstance(idx, int) and 1 <= idx <= len(urls)):
+                continue
+
+            terms: list[dict] = []
+            if isinstance(terms_raw, list):
+                for t in terms_raw:
+                    if not isinstance(t, dict):
+                        continue
+                    term = (t.get("term") or "").strip()
+                    definition = (t.get("def") or t.get("definition") or "").strip()
+                    if term and definition:
+                        terms.append({"term": term, "definition": definition})
+
+            if not background and not terms:
+                continue  # UI tolerates NULL, no need to write empty record
+
+            url = urls[idx - 1]
+            primer_payload = {
+                "background": background.strip(),
+                "terms": terms,
+                "generated_at": now_iso,
+            }
+            try:
+                await pool.execute(
+                    """
+                    UPDATE articles
+                       SET context_primer = $1::jsonb,
+                           updated_at = NOW()
+                     WHERE source_url = $2
+                    """,
+                    json.dumps(primer_payload), url,
+                )
+                updated += 1
+            except Exception as e:
+                logger.error("UPDATE context_primer for %s failed: %s", url, e)
+                failed += 1
+
+    logger.info(json.dumps({
+        "event": "batch_primer_applied",
+        "batch_id": batch_id,
+        "updated": updated,
+        "failed": failed,
+    }))

--- a/workflows/pipeline_workflow.py
+++ b/workflows/pipeline_workflow.py
@@ -164,6 +164,51 @@ async def context_node(state: PipelineState) -> dict:
     return {"contexts": {}, "importance_scores": {}}
 
 
+async def primer_node(state: PipelineState) -> dict:
+    """Civic-literacy MVP Phase 1A: submit background-primer generation to the
+    Message Batches API.
+
+    Same async pattern as context_node — returns immediately, articles are
+    stored with NULL context_primer, the batch poller writes context_primer
+    when the batch completes. The UI tolerates NULL (BackgroundPrimer renders
+    nothing when context_primer is null/empty).
+    """
+    from services.primer_generator import submit_primer_batch
+
+    new_articles = state.get("new_articles", [])
+    summaries = state.get("summaries", {})
+    if not new_articles:
+        return {}
+
+    articles_for_primer = []
+    for article in new_articles:
+        result = summaries.get(article.source_url)
+        summary = result["summary"] if result else ""
+        if summary:
+            articles_for_primer.append({
+                "source_url": article.source_url,
+                "source_name": article.source_name,
+                "title": article.title,
+                "summary": summary,
+            })
+
+    if not articles_for_primer:
+        return {}
+
+    try:
+        batch_id = await submit_primer_batch(articles_for_primer)
+        logger.info(
+            "primer: submitted batch %s for %d articles (async)",
+            batch_id, len(articles_for_primer),
+        )
+    except Exception as e:
+        logger.error("primer batch submission failed: %s", e)
+        return {"errors": state.get("errors", []) + [f"primer: {e}"]}
+
+    # Populated later by the poller → return empty now.
+    return {}
+
+
 async def embed_node(state: PipelineState) -> dict:
     """Generate Voyage AI embeddings for new articles."""
     from services.embedder import embed_texts
@@ -394,6 +439,7 @@ def build_pipeline_graph():
     graph.add_node("deduplicate", deduplicate_node)
     graph.add_node("summarize", summarize_node)
     graph.add_node("context", context_node)
+    graph.add_node("primer", primer_node)
     graph.add_node("embed", embed_node)
     graph.add_node("store", store_node)
 
@@ -401,7 +447,8 @@ def build_pipeline_graph():
     graph.add_edge("fetch_rss", "deduplicate")
     graph.add_edge("deduplicate", "summarize")
     graph.add_edge("summarize", "context")
-    graph.add_edge("context", "embed")
+    graph.add_edge("context", "primer")
+    graph.add_edge("primer", "embed")
     graph.add_edge("embed", "store")
     graph.add_edge("store", END)
 


### PR DESCRIPTION
## Summary

First building block of the civic-literacy MVP. Adds an LLM-generated **background primer** to every ingested article — a "What you should know first" panel with one paragraph of context and 3–5 plain-language term definitions.

See [`plans/sift-civic-literacy.md`](https://github.com/kristenmartino/sift-api/blob/feat/civic-literacy-phase-1-primer/plans/sift-civic-literacy.md) for the multi-phase plan. This PR ships **Phase 1A only**:

- ✅ schema (both new columns: `context_primer` + `reading_levels`)
- ✅ `primer_generator` service (batch + live paths)
- ✅ `primer_node` wired into the pipeline graph
- ✅ poller registration
- ✅ backfill script

What ships **after** this PR:
- Phase 1B: `reading_level_generator` service (writes to the `reading_levels` column the schema added here)
- Phase 1C (in `sift/`): `BackgroundPrimer.tsx` + `ReadingLevelSlider.tsx` components, types, DB-row mapping
- Phases 2–5: outlet provenance, glossary with financial + political surfacing, methodology page, visual register

## Schema

```sql
ALTER TABLE articles ADD COLUMN IF NOT EXISTS context_primer JSONB;
ALTER TABLE articles ADD COLUMN IF NOT EXISTS reading_levels JSONB;
```

`reading_levels` is included in this migration to keep the schema change atomic; it stays NULL until Phase 1B writes to it. UI tolerates NULL on both fields (`BackgroundPrimer` renders nothing without data).

Migration applied two ways:
- `migrations/005_context_primer_and_reading_levels.sql` — for operators applying manually
- `app/db.py:_apply_migrations` — runs at FastAPI startup on Railway, idempotent via `IF NOT EXISTS`

## `context_primer` payload

```jsonc
{
  "background": "One short paragraph of context the reader needs before the lede.",
  "terms": [
    { "term": "filibuster", "definition": "A Senate procedure that requires 60 votes to end debate on most legislation." }
  ],
  "generated_at": "2026-05-04T12:34:56.789Z"
}
```

LLM is allowed to return an empty primer (background `""`, terms `[]`) when an article is short and self-contained — these articles never get a row written and stay NULL.

## Pipeline

```
fetch_rss → deduplicate → summarize → context → primer → embed → store
```

`primer_node` mirrors `context_node`: submits a Message Batches API request (50% discount), returns immediately. The poller picks up the completed batch (typically within minutes) and `process_primer_batch_results` runs the UPDATE.

## Voice

The prompt enforces the project voice doc: *the patient teacher who never makes you feel dumb. Authoritative, never preachy, never partisan, never editorializing.* Explicitly forbids political-position language, "this article is about" meta-prefixes, and the word "context" inside the primer text itself.

## Backfill

```bash
./.venv/bin/python3 scripts/backfill_primers.py [--limit N]
```

Default `--limit 200` matches the figure in the civic-literacy plan. Roughly $1 in Haiku spend at default scale.

## Test plan

- [x] `ruff check` on all touched files — clean
- [x] `py_compile` on all touched files — clean
- [x] Non-FastAPI tests — 43/43 pass locally (`pytest tests/test_summarizer.py tests/test_rss.py tests/test_compare_workflow.py`)
- [ ] CI `lint-test` job — runs full suite against fresh `pip install -r requirements.txt` venv (FastAPI-bound tests work in CI; only fail locally because the local venv is missing `slowapi`)
- [ ] After merge: deploy to Railway and confirm `_apply_migrations` adds both columns idempotently
- [ ] After deploy: spot-check an article's `context_primer` populates after the next pipeline run (~30 min)
- [ ] After deploy: run `scripts/backfill_primers.py --limit 50` against prod, verify primer JSON shape, eyeball a few primers for voice + nonpartisan tone

## Risks & mitigations

| Risk | Mitigation |
|---|---|
| Haiku tone-policing fails (primer editorializes or takes a side) | Conservative prompt; explicit "never editorialize / never take a position" rules; spot-review the first 50 primers post-backfill before promoting to default-rendered. |
| Primer JSON malformed | `_extract_json_array` tolerates leading/trailing prose; `_parse_primers` drops malformed entries silently rather than failing the whole batch. |
| Cost regression | Per-article: ~1500 max_tokens × Haiku-tier batch pricing ≈ $0.005 each. ~50K existing articles × $0.005 ≈ $250 if we ever fully backfill — but the default backfill is 200 articles ≈ $1, and per-day ingest (~500 articles) is ~$2.50/day. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)