### PR TITLE
prompt(primer): add source-attribution clause

### DIFF
--- a/services/primer_generator.py
+++ b/services/primer_generator.py
@@ -59,6 +59,10 @@ Critical rules:
 - Never use the word "context" in the primer itself.
 - Never start with "This article is about" or similar meta-language.
 - Never recommend a position or imply one is correct.
+- When paraphrasing a third-party finding (a court ruling, regulator decision, panel determination, audit, study), \
+preserve the source attribution: write "the court ruled the probe overstepped her authority" not "the probe \
+overstepped her authority." The primer surfaces what's known to whom — never the LLM's own legal, political, \
+or moral assessment of facts a third party determined.
 - If the article is short or self-contained and needs no context, return background as an empty string \
 and terms as an empty array. The UI hides empty primers.
 


### PR DESCRIPTION
## Summary

Tiny follow-up to closed issue [#21](https://github.com/kristenmartino/sift-api/issues/21). Adds an explicit prompt rule requiring source attribution when the primer paraphrases a third-party finding (court ruling, regulator decision, panel determination, audit, study).

## Why now (and why so small)

Investigation under #21 found the drift is rare in practice — 0 true-positive cases across 200 random primers from prod. So this isn't a fix for a widespread problem; it's belt-and-suspenders for the rare close-to-the-line outlier (the original "Pirro overstepped her authority" sample from Phase 1A spot-check, which is real but appears 1-in-200+).

Cheap, no downside, marginally improves a class of primer Sift can't afford to get wrong on a civic-literacy product specifically: who said what.

## What changes

Adds one rule to `_PROMPT_HEADER` in `services/primer_generator.py`, immediately after the "Never recommend a position" rule (same family — things the LLM must not assert as its own):

> When paraphrasing a third-party finding (a court ruling, regulator decision, panel determination, audit, study), preserve the source attribution: write "the court ruled the probe overstepped her authority" not "the probe overstepped her authority." The primer surfaces what's known to whom — never the LLM's own legal, political, or moral assessment of facts a third party determined.

## What this does NOT do

- **Doesn't backfill or re-generate** the 2,263 primers already in prod. They passed the post-investigation 200-sample voice check; rewriting them is unjustified spend.
- **Doesn't touch term-selection drift** (closed [#20](https://github.com/kristenmartino/sift-api/issues/20)) — 0/60 in the wider sample, prompt is already working.
- **Doesn't change the primer JSON schema or output shape.**

## Test plan

- [x] `ruff check services/primer_generator.py` — clean
- [x] `py_compile services/primer_generator.py` — clean
- [ ] After merge: spot-check 5 primers from the next pipeline run for the type of article most likely to trigger the rule (legal/regulatory stories) and confirm attribution is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)