### PR TITLE
feat(rss): tighten source whitelist to ~50 curated outlets (Phase 2.0)

### DIFF
--- a/services/rss.py
+++ b/services/rss.py
@@ -16,7 +16,32 @@ from app.models import RSSArticle
 
 logger = logging.getLogger("sift-api.rss")
 
-# All RSS feeds — category is assigned by AI during summarization
+# RSS feeds — Phase 2.0 (civic-literacy MVP).
+#
+# Pruned from ~110 long-tail feeds to ~50 outlets that map to a curated
+# outlet_profiles whitelist (forthcoming in Phase 2.A). The trim aligns
+# Sift's marketing claim ("vetted outlets across the political spectrum")
+# with what we actually ingest from. See plans/sift-civic-literacy.md and
+# plans/sift-phase-2-cross-spectrum-and-outlet-provenance.md.
+#
+# Inclusion criteria for the curated set:
+#   • MBFC factual-accuracy rating ≥ "Mixed" (we exclude "Low" / "Very Low")
+#   • Identifiable masthead, corrections policy, and bylines
+#   • AllSides-rated when applicable; symmetric L/C/R representation
+#   • Specialty outlets (Nature, Bloomberg, etc.) included when they
+#     dominate a sector regardless of bias-spectrum positioning
+#
+# Categories sports + entertainment fall *outside* the civic-literacy
+# framework — their feeds are kept here as fallback content so the
+# corresponding /news category tabs don't empty out, but those articles
+# do not get cross-spectrum or outlet-provenance treatments. Whether
+# those categories survive long-term is a separate product call.
+#
+# Outlets on the curated list that DON'T currently have an RSS feed
+# wired here (CNN, MSNBC, Fox News, NY Post, National Review, WSJ,
+# Daily Wire, Federalist, Daily Caller, etc.) get added in Phase 2.A
+# along with their outlet_profiles seed entries.
+
 FEEDS: list[tuple[str, str]] = [
     # ── General / Wire services ──────────────────────────
     ("AP News", "https://apnews.com/world-news.rss"),
@@ -33,128 +58,56 @@ FEEDS: list[tuple[str, str]] = [
     ("CBS News", "https://www.cbsnews.com/latest/rss/main"),
     ("New York Times", "https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml"),
     ("Washington Post", "https://feeds.washingtonpost.com/rss/national"),
-    # ── Technology ───────────────────────────────────────
-    ("TechCrunch", "https://techcrunch.com/feed/"),
+    # ── Technology (specialty) ───────────────────────────
     ("Ars Technica", "https://feeds.arstechnica.com/arstechnica/index"),
     ("The Verge", "https://www.theverge.com/rss/index.xml"),
     ("Wired", "https://www.wired.com/feed/rss"),
     ("MIT Tech Review", "https://www.technologyreview.com/feed/"),
-    ("Hacker News", "https://hnrss.org/frontpage?points=50"),
-    ("Engadget", "https://www.engadget.com/rss.xml"),
-    ("ZDNet", "https://www.zdnet.com/news/rss.xml"),
-    ("The Register", "https://www.theregister.com/headlines.atom"),
-    ("IEEE Spectrum", "https://spectrum.ieee.org/feeds/feed.rss"),
-    ("VentureBeat", "https://venturebeat.com/feed/"),
-    ("9to5Mac", "https://9to5mac.com/feed/"),
-    ("9to5Google", "https://9to5google.com/feed/"),
-    ("Android Central", "https://www.androidcentral.com/feed"),
-    ("Tom's Hardware", "https://www.tomshardware.com/feeds/all"),
-    ("TechMeme", "https://www.techmeme.com/feed.xml"),
-    ("Decrypt", "https://decrypt.co/feed"),
     # ── Business & Finance ───────────────────────────────
     ("CNBC", "https://www.cnbc.com/id/100003114/device/rss/rss.html"),
-    ("MarketWatch", "https://www.marketwatch.com/rss/topstories"),
     ("Reuters Business", "https://openrss.org/feed/www.reuters.com/business"),
     ("Financial Times", "https://www.ft.com/rss/home"),
     ("The Economist", "https://www.economist.com/finance-and-economics/rss.xml"),
-    ("Fortune", "https://fortune.com/feed/fortune-feeds/?id=3230629"),
-    ("Business Insider", "https://feeds2.feedburner.com/businessinsider"),
-    ("Yahoo Finance", "https://finance.yahoo.com/news/rssindex"),
     ("Bloomberg", "https://feeds.bloomberg.com/markets/news.rss"),
-    ("Quartz", "https://qz.com/feed"),
     ("Forbes", "https://www.forbes.com/innovation/feed2"),
-    # ── Science ──────────────────────────────────────────
+    # ── Science (specialty) ──────────────────────────────
     ("Nature", "https://www.nature.com/nature.rss"),
     ("Science (AAAS)", "https://www.science.org/rss/news_current.xml"),
-    ("Phys.org", "https://phys.org/rss-feed/"),
-    ("New Scientist", "https://www.newscientist.com/feed/home/"),
-    ("Scientific American", "http://rss.sciam.com/ScientificAmerican-Global"),
-    ("Live Science", "https://www.livescience.com/feeds.xml"),
-    ("Space.com", "https://www.space.com/feeds.xml"),
-    ("ArXiv AI", "https://rss.arxiv.org/rss/cs.AI"),
-    ("NASA", "https://www.nasa.gov/rss/dyn/breaking_news.rss"),
-    ("Smithsonian", "https://www.smithsonianmag.com/rss/science-nature/"),
-    ("Quanta Magazine", "https://api.quantamagazine.org/feed/"),
-    ("ScienceDaily", "https://www.sciencedaily.com/rss/all.xml"),
-    ("Science News", "https://www.sciencenews.org/feed"),
-    ("Undark", "https://undark.org/feed/"),
-    ("Medical Xpress", "https://medicalxpress.com/rss-feed/"),
     # ── Energy & Climate ─────────────────────────────────
-    ("Utility Dive", "https://www.utilitydive.com/feeds/news/"),
-    ("Solar Power World", "https://www.solarpowerworldonline.com/feed/"),
-    ("Renewable Energy World", "https://www.renewableenergyworld.com/feed/"),
-    ("E&E News", "https://www.eenews.net/feed/"),
     ("Canary Media", "https://www.canarymedia.com/rss.rss"),
-    ("CleanTechnica", "https://cleantechnica.com/feed/"),
-    ("Electrek", "https://electrek.co/feed/"),
     ("Carbon Brief", "https://www.carbonbrief.org/feed"),
-    ("Greentech Media", "https://www.greentechmedia.com/feed"),
-    ("Energy Monitor", "https://www.energymonitor.ai/feed/"),
-    ("Grist", "https://grist.org/feed/"),
     ("Inside Climate News", "https://insideclimatenews.org/feed/"),
     # ── World & Geopolitics ──────────────────────────────
     ("BBC World", "http://feeds.bbci.co.uk/news/world/rss.xml"),
-    ("Al Jazeera", "https://www.aljazeera.com/xml/rss/all.xml"),
     ("The Guardian World", "https://www.theguardian.com/world/rss"),
-    ("DW News", "https://rss.dw.com/rdf/rss-en-top"),
-    ("France 24", "https://www.france24.com/en/rss"),
     ("NPR World", "https://feeds.npr.org/1004/rss.xml"),
     ("Foreign Policy", "https://foreignpolicy.com/feed/"),
-    ("The Diplomat", "https://thediplomat.com/feed/"),
-    ("South China Morning Post", "https://www.scmp.com/rss/91/feed"),
-    ("Japan Times", "https://www.japantimes.co.jp/feed/"),
     ("Reuters World", "https://openrss.org/feed/www.reuters.com/world"),
-    ("ABC Australia", "https://www.abc.net.au/news/feed/51120/rss.xml"),
-    ("Times of India", "https://timesofindia.indiatimes.com/rssfeedstopstories.cms"),
-    ("Politico EU", "https://www.politico.eu/feed/"),
-    ("Defense One", "https://www.defenseone.com/rss/"),
     ("The Intercept", "https://theintercept.com/feed/?rss"),
     # ── Health & Medicine ────────────────────────────────
     ("STAT News", "https://www.statnews.com/feed/"),
     ("NPR Health", "https://feeds.npr.org/1128/rss.xml"),
     ("WHO", "https://www.who.int/rss-feeds/news-english.xml"),
-    ("Health Affairs", "https://www.healthaffairs.org/action/showFeed?type=etoc&feed=rss&jc=hlthaff"),
-    ("Fierce Healthcare", "https://www.fiercehealthcare.com/rss/xml"),
-    ("CDC MMWR", "https://tools.cdc.gov/api/v2/resources/media/342778.rss"),
-    ("Medscape", "https://www.medscape.com/cx/rssfeeds/2700.xml"),
-    ("The BMJ", "https://www.bmj.com/rss/recent.xml"),
-    ("NIH News", "https://www.nih.gov/news-releases/feed.xml"),
-    ("The Lancet", "https://www.thelancet.com/rssfeed/lancet_current.xml"),
-    ("Healio", "https://www.healio.com/rss"),
-    # ── Politics ────────────────────────────────────────
+    # ── Politics ─────────────────────────────────────────
     ("Politico Congress", "https://rss.politico.com/congress.xml"),
     ("The Hill Politics", "https://thehill.com/homenews/feed/"),
-    ("RealClearPolitics", "https://feeds.feedburner.com/realclearpolitics/qlMj"),
-    ("FiveThirtyEight", "https://fivethirtyeight.com/features/feed/"),
-    ("Roll Call", "https://www.rollcall.com/feed/"),
     ("The Dispatch", "https://thedispatch.com/feed/"),
-    ("Ballot Access News", "https://ballot-access.org/feed/"),
-    ("OpenSecrets", "https://www.opensecrets.org/news/feed/"),
-    # ── Sports ─────────────────────────────────────────
+    # ── Sports (out-of-scope for civic-literacy mechanics) ──
     ("ESPN", "https://www.espn.com/espn/rss/news"),
     ("BBC Sport", "http://feeds.bbci.co.uk/sport/rss.xml"),
-    ("The Athletic", "https://theathletic.com/feeds/rss/news/"),
     ("CBS Sports", "https://www.cbssports.com/rss/headlines/"),
-    ("Bleacher Report", "https://bleacherreport.com/articles/feed"),
     ("Sports Illustrated", "https://www.si.com/rss/si_topstories.rss"),
-    ("Yahoo Sports", "https://sports.yahoo.com/rss/"),
-    ("Deadspin", "https://deadspin.com/rss"),
-    # ── Entertainment ──────────────────────────────────
+    # ── Entertainment (out-of-scope for civic-literacy mechanics) ──
     ("Variety", "https://variety.com/feed/"),
     ("The Hollywood Reporter", "https://www.hollywoodreporter.com/feed/"),
     ("Deadline", "https://deadline.com/feed/"),
-    ("Entertainment Weekly", "https://ew.com/feed/"),
     ("Rolling Stone", "https://www.rollingstone.com/feed/"),
     ("Pitchfork", "https://pitchfork.com/feed/feed-news/rss"),
-    ("IGN", "https://feeds.feedburner.com/ign/all"),
-    ("Polygon", "https://www.polygon.com/rss/index.xml"),
     # ── Additional general-interest ──────────────────────
     ("Slate", "https://slate.com/feeds/all.rss"),
     ("Vox", "https://www.vox.com/rss/index.xml"),
     ("The Atlantic", "https://www.theatlantic.com/feed/all/"),
-    ("The Conversation", "https://theconversation.com/us/articles.atom"),
     ("ProPublica", "https://www.propublica.org/feeds/propublica/main"),
-    ("Rest of World", "https://restofworld.org/feed/"),
 ]
 
 MAX_ENTRIES_PER_FEED = 10

--- a/tests/test_rss.py
+++ b/tests/test_rss.py
@@ -96,8 +96,15 @@ class TestParseFeed:
 
 class TestFeedConfig:
     def test_feed_count(self):
-        # Flat list of (name, url) tuples — 128 feeds after adding politics/sports/entertainment
-        assert len(FEEDS) >= 100
+        # Civic-literacy MVP (Phase 2.0): curated outlet whitelist.
+        # Lower bound guards against accidental empty-feed deploys; upper
+        # bound flags drift back into the long-tail aggregator era.
+        # See plans/sift-phase-2-cross-spectrum-and-outlet-provenance.md.
+        assert 40 <= len(FEEDS) <= 70, (
+            f"FEEDS count ({len(FEEDS)}) is outside the curated range. "
+            "Adding feeds? Confirm the outlet is on the curated list. "
+            "Cutting? Confirm a category isn't left empty."
+        )
 
     def test_feeds_are_tuples(self):
         for feed in FEEDS:


### PR DESCRIPTION
## Summary

Cut the `FEEDS` list from ~110 long-tail entries to 54 feeds across ~40 canonical outlets. Aligns ingest with the civic-literacy curation policy that Phase 2.A will formalize via `outlet_profiles`.

Companion PR in `sift` (separate repo) updates the matching marketing copy: *"hundreds of sources"* / *"100+ outlets"* → *"~50 vetted outlets across the political spectrum"*.

## Why Phase 2.0

The marketing copy currently inflates the source count (a holdover from the pre-pivot positioning where breadth was the pitch). Civic-literacy positioning values **curation quality, not volume.** *"~50 vetted outlets, every rating linked to the source"* is a stronger pitch than *"100+ sources"* with no enumeration. Bringing ingest reality in line with that pitch is cheap to do now and lets Phase 2.A seed `outlet_profiles` confidently against a known set.

## Inclusion criteria (documented in the file header)

- MBFC factual-accuracy rating ≥ "Mixed" (excludes "Low" / "Very Low")
- Identifiable masthead, corrections policy, bylines
- AllSides-rated when applicable; symmetric L / C / R representation
- Specialty outlets included where they dominate a sector regardless of bias-spectrum positioning (Nature, Bloomberg, MIT Tech Review, etc.)

## What's cut (~60 feeds)

| Category | Cut |
|---|---|
| Tech long-tail | TechCrunch, Engadget, ZDNet, The Register, IEEE Spectrum, VentureBeat, 9to5Mac, 9to5Google, Android Central, Tom's Hardware, TechMeme, Decrypt, Hacker News |
| Business long-tail | MarketWatch, Fortune, Business Insider, Yahoo Finance, Quartz |
| Science long-tail | Phys.org, New Scientist, Scientific American, Live Science, Space.com, ArXiv AI, NASA, Smithsonian, Quanta, ScienceDaily, Science News, Undark, Medical Xpress |
| Energy long-tail | Utility Dive, Solar Power World, Renewable Energy World, E&E News, CleanTechnica, Electrek, Greentech Media, Energy Monitor, Grist |
| World long-tail | Al Jazeera, DW News, France 24, The Diplomat, SCMP, Japan Times, ABC Australia, Times of India, Politico EU, Defense One |
| Health long-tail | Health Affairs, Fierce Healthcare, CDC MMWR, NIH, The BMJ, Medscape, The Lancet, Healio |
| Politics long-tail | RealClearPolitics, FiveThirtyEight, Roll Call, Ballot Access News, OpenSecrets |
| Sports | Trimmed from 8 to 4 |
| Entertainment | Trimmed from 8 to 5 |
| General-interest | The Conversation, Rest of World |

## What's kept

- All 50-ish curated outlets that already had RSS feeds in the prior list
- Sports + entertainment kept as fallback content so those `/news` category tabs don't empty (these are **out-of-scope for civic-literacy treatments** — cross-spectrum compare and outlet provenance won't apply to them; flagged in the file header as a separate product call to revisit)

## What's still missing (Phase 2.A will add)

Several curated outlets don't have RSS feeds wired here yet — **CNN, MSNBC, Fox News, NY Post, National Review, WSJ, Daily Wire, Federalist, Daily Caller, Mother Jones, The Nation, Free Press, American Conservative, Bulwark.** Phase 2.A's seed work adds their RSS feeds together with their `outlet_profiles` entries.

## Test plan

- [x] `pytest tests/test_rss.py` — 17/17 passing
- [x] `ruff check services/rss.py tests/test_rss.py` — clean
- [x] `py_compile services/rss.py` — clean
- [x] `test_rss.py:test_feed_count` updated: was `>= 100` (encoded the pre-pivot claim); now asserts `40 <= len(FEEDS) <= 70` with a clear error message guarding both the lower bound (accidental empty-feed deploys) and the upper bound (drift back into the long-tail era)
- [ ] After merge: spot-check that the next ingest cycle pulls cleanly from all 54 feeds with no broken-RSS regressions; `articles` table source_name distribution should consolidate around the curated set

🤖 Generated with [Claude Code](https://claude.com/claude-code)