### PR TITLE
fix(clustering): require ≥2 unique outlets to persist a story

### DIFF
--- a/workflows/story_workflow.py
+++ b/workflows/story_workflow.py
@@ -173,6 +173,7 @@ async def synthesize_and_store_node(state: StoryState) -> dict:
         category,
     )
 
+    skipped_single_outlet = 0
     for cluster in clusters:
         indices = cluster.get("article_indices", [])
         event = cluster.get("event", "")
@@ -184,6 +185,24 @@ async def synthesize_and_store_node(state: StoryState) -> dict:
                 cluster_articles.append(articles[idx - 1])
 
         if len(cluster_articles) < 2:
+            continue
+
+        # Civic-literacy MVP requirement: a "story" must reflect cross-outlet
+        # coverage, not one outlet publishing several near-duplicate articles
+        # about the same event. Without this gate the clusterer happily groups
+        # 4× 9to5Mac posts about an Apple release into a "story" that the UI
+        # then misrenders as "How 4 outlets covered this." sift PR #72 patches
+        # the symptom at render; this is the durable data-layer fix.
+        unique_outlets = {a.get("source_name") for a in cluster_articles if a.get("source_name")}
+        if len(unique_outlets) < 2:
+            skipped_single_outlet += 1
+            logger.info(json.dumps({
+                "event": "cluster_dropped_single_outlet",
+                "category": category,
+                "outlet": next(iter(unique_outlets), "unknown"),
+                "article_count": len(cluster_articles),
+                "cluster_event": event,
+            }))
             continue
 
         # Generate stable story ID from sorted article IDs
@@ -276,7 +295,10 @@ async def synthesize_and_store_node(state: StoryState) -> dict:
         except Exception as e:
             logger.error("Failed to store story %s: %s", story_id, e)
 
-    logger.info("synthesize_and_store [%s]: created/updated %d stories", category, len(stories))
+    logger.info(
+        "synthesize_and_store [%s]: created/updated %d stories (skipped %d single-outlet clusters)",
+        category, len(stories), skipped_single_outlet,
+    )
     return {"stories": stories}
 
 


### PR DESCRIPTION
## Summary

Drops single-outlet clusters at the synthesize-and-store step before they ever become rows in the `stories` table. The **durable backend complement** to [sift PR #72](https://github.com/kristenmartino/sift/pull/72), which patched the misleading *"How 4 outlets covered this"* render symptom at the frontend.

## The bug

When one outlet (the textbook case: 9to5Mac with `Apple highl…` / `rolls…` / `debu…` / `relea…` near-duplicate posts about the same iOS RC release) publishes several articles about the same event, the LLM clusterer correctly groups them as same-event coverage. **Without an outlet-diversity gate, those clusters get synthesized + persisted as multi-source stories, and the UI presents them as cross-outlet coverage.** They aren't.

## The fix

In `workflows/story_workflow.py` `synthesize_and_store_node`, after the existing `len(cluster_articles) < 2 → continue` guard, add an analogous `len({a.source_name for a in cluster}) < 2 → continue` check.

The clusterer's grouping logic (LLM finding articles about the same event) is unchanged. The **persistence policy** refuses single-outlet clusters separately, so the data layer never holds rows that violate the cross-outlet contract.

## Side benefit: real cost savings

Skips the (expensive) `story_synthesizer` Haiku call on every single-outlet cluster. Saves Haiku tokens proportional to how many same-outlet clusters the LLM would have produced — observably non-zero given how often outlets like 9to5Mac and CNN multi-take a single event.

## Logging

Two log additions for ongoing visibility:

- **Per dropped cluster**: structured JSON line at INFO with `category`, `outlet`, `article_count`, `cluster_event`. Lets us audit how often the gate fires and whether the LLM is over-producing same-outlet clusters.
- **Per category run**: existing *"created/updated N stories"* line now also reports skipped count: *"(skipped M single-outlet clusters)"*.

## What this does NOT do

- **Doesn't backfill** the existing `stories` table. Single-outlet stories already persisted will remain until either:
  1. The clusterer re-runs and re-groups them with new articles from other outlets (legit), OR
  2. All member articles age out of the 48h recency window and the cluster naturally evaporates on the next pass.
- **Doesn't change LLM clustering**. The clusterer still groups same-event articles regardless of outlet.
- **Doesn't make [sift PR #72](https://github.com/kristenmartino/sift/pull/72) redundant**. That render-layer fix still defends against any pre-existing single-outlet stories in the table until they age out. Belt-and-suspenders.

## Test plan

- [x] `ruff check workflows/story_workflow.py` — clean
- [x] `py_compile workflows/story_workflow.py` — clean
- [x] Non-FastAPI tests (`test_rss`, `test_summarizer`, `test_compare_workflow`) — 43/43 passing
- [ ] CI `lint-test` job runs full suite green
- [ ] After merge: deploy to Railway, watch the next story-threading run for `cluster_dropped_single_outlet` log lines. Spot-check a handful — confirm dropped clusters are genuinely same-outlet (not legitimate cross-outlet stories misclassified)
- [ ] After 48h: confirm legacy single-outlet stories naturally drop out as their member articles age past the recency window

🤖 Generated with [Claude Code](https://claude.com/claude-code)