### PR TITLE
fix(entity-linker): drop last-name-only aliases — surface common-noun false positives

### DIFF
--- a/services/entity_linker.py
+++ b/services/entity_linker.py
@@ -20,10 +20,15 @@ auditable. Trade-off: misses common surface-form variants (e.g.,
 
 Aliases applied:
 
-* Politicians: full canonical name + last-name-only IF the last name is
-  unique across the curated 535-member set. So "Schumer" matches Chuck
-  Schumer, but "Jones" matches none of the multiple Joneses (handled at
-  catalog-build time by counting last-name frequencies).
+* Politicians: full canonical name only. We deliberately do NOT alias
+  to last-name-only — even with uniqueness + length checks, common-noun
+  surnames (Cloud, Self, Case, Strong, Banks, Hill, Young, Downing, ...)
+  generate constant false positives in news copy ("cloud computing",
+  "the case involves", "Cloud AI", "China Asks Banks to Pause", etc.).
+  Recall trade-off accepted: a "Schumer said" reference loses its link,
+  but journalism typically introduces politicians by full name on first
+  mention — which we still catch. Better to under-link than mislink for
+  a portfolio site whose credibility hinges on signal-to-noise.
 * Orgs: full canonical name only. Initials/abbreviations are too
   ambiguous without per-org curation.
 * Bills: short_title (when present) + bill_id ("hr-5376-117"). The
@@ -150,18 +155,26 @@ def build_search_dict(
 def politician_aliases(name: str, lastname_freq: Counter[str]) -> list[str]:
     """Build a list of acceptable surface forms for a politician.
 
-    - Always: the full canonical name verbatim.
-    - When the last-name is unique across the catalog: last name alone.
-      "Schumer" matches Chuck Schumer because no other curated
-      politician shares that last name.
+    Returns an empty list — only the full canonical name is searchable.
+
+    Last-name-only aliases were originally added when uniqueness +
+    `_MIN_KEY_LENGTH` were assumed sufficient guards. They aren't.
+    Common-noun surnames in the curated roster (Cloud, Self, Case,
+    Strong, Banks, Hill, Young, Downing, Field, Stone, Reed, Forest, ...)
+    constantly false-match in news copy and even more so in title-cased
+    headlines ("Cloud AI", "China Asks Banks to Pause"), where
+    case-sensitivity alone wouldn't help.
+
+    Kept as a function (rather than inlined) so a future Phase 3.G.2
+    can add back smarter aliasing — e.g., LLM-confirmed mention type,
+    or a curated common-noun blocklist — without changing the call site
+    in `build_catalog`.
+
+    `lastname_freq` is now unused but kept in the signature so callers
+    don't break (and so we still need `Counter` if the policy reverses).
     """
-    aliases: list[str] = []
-    parts = name.strip().split()
-    if len(parts) >= 2:
-        last = parts[-1]
-        if lastname_freq.get(last.lower(), 0) == 1 and len(last) >= _MIN_KEY_LENGTH:
-            aliases.append(last)
-    return aliases
+    del name, lastname_freq  # explicit no-op until Phase 3.G.2
+    return []
 
 
 def build_catalog(

--- a/tests/test_entity_linker.py
+++ b/tests/test_entity_linker.py
@@ -12,33 +12,60 @@ from services.entity_linker import (
 
 
 # ── politician_aliases ──────────────────────────────────────
+#
+# Policy (current): no aliases. We deliberately drop last-name-only
+# matching because common-noun surnames in the curated roster (Cloud,
+# Self, Case, Strong, Banks, Hill, Young, Downing, Green, ...)
+# constantly false-match in news copy. See the module docstring for the
+# precision-vs-recall trade-off.
+#
+# Tests assert the no-alias behavior holds across the input shapes the
+# function previously branched on, so a future Phase 3.G.2 reverse can't
+# silently regress.
 
 
-def test_politician_aliases_unique_lastname():
-    """Last names that appear once in the catalog become aliases."""
+def test_politician_aliases_returns_empty_for_unique_lastname():
+    """Even unique last names get no alias (was: returned [last])."""
     freq = Counter({"schumer": 1, "warren": 1, "jones": 3})
-    assert politician_aliases("Chuck Schumer", freq) == ["Schumer"]
-    assert politician_aliases("Elizabeth Warren", freq) == ["Warren"]
+    assert politician_aliases("Chuck Schumer", freq) == []
+    assert politician_aliases("Elizabeth Warren", freq) == []
 
 
-def test_politician_aliases_ambiguous_lastname():
-    """Last names that appear multiple times stay out of the alias set."""
+def test_politician_aliases_returns_empty_for_ambiguous_lastname():
+    """Ambiguous last names also get no alias (unchanged behavior)."""
     freq = Counter({"jones": 3, "smith": 2})
     assert politician_aliases("Mary Jones", freq) == []
     assert politician_aliases("Bob Smith", freq) == []
 
 
-def test_politician_aliases_single_token_name():
-    """Names without a last-name token return no aliases."""
+def test_politician_aliases_returns_empty_for_single_token_name():
+    """Single-token names get no alias (unchanged behavior)."""
     freq = Counter({"madonna": 1})
     assert politician_aliases("Madonna", freq) == []
 
 
-def test_politician_aliases_short_lastname():
-    """Last names below the min-key length threshold are dropped."""
-    # _MIN_KEY_LENGTH = 4; "Wu" is too short to be a useful alias.
+def test_politician_aliases_returns_empty_for_short_lastname():
+    """Short last names get no alias (unchanged behavior)."""
     freq = Counter({"wu": 1})
     assert politician_aliases("Michelle Wu", freq) == []
+
+
+def test_politician_aliases_no_false_match_on_common_noun_surnames():
+    """Regression: 'Cloud', 'Self', 'Case', 'Strong', 'Banks', 'Green',
+    'Young', 'Downing' all live in the real roster. The pre-fix policy
+    produced last-name aliases for each, which then false-matched in
+    news copy ('cloud computing', 'the case involves', 'Cloud AI',
+    'China Asks Banks to Pause', 'green steel', 'young people',
+    'self-improving AI', 'downing power lines'). The fix is no aliases."""
+    freq = Counter({s: 1 for s in (
+        "cloud", "self", "case", "strong", "banks",
+        "green", "young", "downing",
+    )})
+    for full in (
+        "Michael Cloud", "Keith Self", "Ed Case", "Dale Strong",
+        "Jim Banks", "Al Green", "Todd Young", "Troy Downing",
+    ):
+        assert politician_aliases(full, freq) == [], full
 
 
 # ── build_catalog ────────────────────────────────────────────
@@ -86,23 +113,22 @@ def test_build_catalog_skips_rows_missing_required_fields():
     }
 
 
-def test_build_catalog_politician_aliases_applied():
+def test_build_catalog_politicians_have_no_aliases():
+    """Politician rows now carry no aliases — only the full canonical
+    name is searchable. See politician_aliases policy note."""
     catalog = build_catalog(
         outlets=[],
         politicians=[
-            {"bioguide_id": "S000148", "name": "Chuck Schumer"},  # unique
+            {"bioguide_id": "S000148", "name": "Chuck Schumer"},
             {"bioguide_id": "J001", "name": "Mary Jones"},
-            {"bioguide_id": "J002", "name": "Bob Jones"},  # ambiguous
+            {"bioguide_id": "J002", "name": "Bob Jones"},
         ],
         orgs=[],
         bills=[],
     )
-    schumer = next(r for r in catalog if r["canonical_id"] == "S000148")
-    mary = next(r for r in catalog if r["canonical_id"] == "J001")
-    bob = next(r for r in catalog if r["canonical_id"] == "J002")
-    assert "Schumer" in schumer["aliases"]
-    assert mary["aliases"] == []  # Jones is shared with Bob
-    assert bob["aliases"] == []
+    for row in catalog:
+        if row["type"] == "politician":
+            assert row["aliases"] == [], row["primary_name"]
 
 
 def test_build_catalog_bill_uses_short_title_or_falls_back_to_title():
@@ -227,14 +253,21 @@ def test_link_text_case_insensitive():
 
 
 def test_link_text_collapses_duplicate_canonicals():
-    """Same entity matched via two keys (name + alias) → single link."""
+    """Same entity matched via two keys (e.g., bill name + bill_id) → single
+    link. (Politicians no longer get aliases, but bills still do —
+    short_title + bill_id, plus year-stripped form.)"""
     d = _dict({
-        "chuck schumer": ("politician", "S000148"),
-        "schumer": ("politician", "S000148"),
+        "inflation reduction act of 2022": ("bill", "hr-5376-117"),
+        "inflation reduction act": ("bill", "hr-5376-117"),
+        "hr-5376-117": ("bill", "hr-5376-117"),
     })
-    out = link_text("Chuck Schumer met with Schumer", d)
+    out = link_text(
+        "The Inflation Reduction Act of 2022, also called the Inflation "
+        "Reduction Act, is hr-5376-117.",
+        d,
+    )
     assert len(out) == 1
-    assert out[0]["canonical_id"] == "S000148"
+    assert out[0]["canonical_id"] == "hr-5376-117"
 
 
 def test_link_text_preserves_original_casing_in_surface_form():


### PR DESCRIPTION
## Live bug
\"MENTIONED IN THIS STORY\" chips on the dossier-enabled article cards are resolving common English words to politicians whose last names happen to be common nouns. Reported via screenshots:

| Article copy fragment | False chip | Curated politician |
|---|---|---|
| \"downing power lines\" | \`downing\` | Troy Downing (R-MT) |
| \"the case involves\" | \`case\` | Ed Case (D-HI) |
| \"self-improving AI\" | \`self\` | Keith Self (R-TX) |
| \"young people\" | \`young\` | Todd Young (R-IN) |
| \"strong competition\" | \`strong\` | Dale Strong (R-AL) |
| \"green steel\" | \`green\` | Al Green (D-TX) |
| \"Cloud AI\" | \`cloud\` | Michael Cloud (R-TX) |
| \"China Asks Banks to Pause\" | \`Banks\` | Jim Banks (R-IN) |

These chips link to politician dossiers unrelated to the article — actively misleading on a portfolio civic-literacy site.

## Root cause
\`politician_aliases\` added the last-name-only as an alias whenever the last name was unique across the catalog and ≥4 chars. Combined with case-insensitive \`\\b...\\b\` matching, common-noun surnames produced constant false matches.

Even case-sensitive matching wouldn't have rescued title-cased false positives like \"Cloud AI\" or \"Banks to Pause\" — those words really are capitalized in the source text.

## Fix
\`politician_aliases\` now returns \`[]\` unconditionally. Only the full canonical name (\"Chuck Schumer\") is searchable.

**Recall trade-off**: subsequent-mention \"Schumer said today\" references lose their link if the surname appears alone. Acceptable for MVP — journalism introduces politicians by full name on first mention, which we still catch. **Better to under-link than mislink** for a portfolio site whose credibility hinges on signal-to-noise.

The function signature is preserved so a future Phase 3.G.2 can layer back smarter aliasing (LLM-confirmed mention type, curated common-noun blocklist) without touching \`build_catalog\`.

## Tests
- New: \`test_politician_aliases_no_false_match_on_common_noun_surnames\` — regression for the 8 surnames in the bug report.
- Updated existing tests to assert the no-alias policy across all previously-branched input shapes.
- 23/23 entity_linker tests pass.

## Followup (out of scope)
1. **Backfill** \`articles.entity_links\` for stored articles — the JSONB rows in prod still contain the bad chips. Either a one-shot script that re-runs \`link_articles\` over all stored articles, or trust the next pipeline refresh to overwrite them. Recommend the one-shot script (refresh only touches new articles).
2. RSS dead-feed cleanup from the parallel spawned task is stashed locally and will land in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)