### PR TITLE
fix(rss): replace 4 dead feeds (AP, SI, Reuters, WaPo)

### DIFF
--- a/services/rss.py
+++ b/services/rss.py
@@ -44,8 +44,12 @@ logger = logging.getLogger("sift-api.rss")
 
 FEEDS: list[tuple[str, str]] = [
     # ── General / Wire services ──────────────────────────
-    ("AP News", "https://apnews.com/world-news.rss"),
-    ("Reuters", "https://openrss.org/feed/www.reuters.com"),
+    # AP News and Reuters retired their public RSS feeds (AP behind an
+    # auth-walled API; Reuters killed RSS in 2020). The openrss.org
+    # wrapper for Reuters is now rate-limiting us (HTTP 429). Wire copy
+    # from both still reaches Sift via NPR / CBS / USA Today / ABC /
+    # BBC / Guardian, all of which run AP and Reuters syndication.
+    # TODO: revisit if/when we acquire AP API or Reuters Connect access.
     ("NPR", "https://feeds.npr.org/1001/rss.xml"),
     ("BBC", "http://feeds.bbci.co.uk/news/rss.xml"),
     ("Axios", "https://api.axios.com/feed/"),
@@ -57,7 +61,9 @@ FEEDS: list[tuple[str, str]] = [
     ("ABC News", "https://abcnews.go.com/abcnews/topstories"),
     ("CBS News", "https://www.cbsnews.com/latest/rss/main"),
     ("New York Times", "https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml"),
-    ("Washington Post", "https://feeds.washingtonpost.com/rss/national"),
+    # WaPo: /rss/national was returning ~5 items (and intermittently empty
+    # on Railway egress); /rss/homepage is the full firehose (~70 items).
+    ("Washington Post", "https://feeds.washingtonpost.com/rss/homepage"),
     # ── Technology (specialty) ───────────────────────────
     ("Ars Technica", "https://feeds.arstechnica.com/arstechnica/index"),
     ("The Verge", "https://www.theverge.com/rss/index.xml"),
@@ -65,7 +71,6 @@ FEEDS: list[tuple[str, str]] = [
     ("MIT Tech Review", "https://www.technologyreview.com/feed/"),
     # ── Business & Finance ───────────────────────────────
     ("CNBC", "https://www.cnbc.com/id/100003114/device/rss/rss.html"),
-    ("Reuters Business", "https://openrss.org/feed/www.reuters.com/business"),
     ("Financial Times", "https://www.ft.com/rss/home"),
     ("The Economist", "https://www.economist.com/finance-and-economics/rss.xml"),
     ("Bloomberg", "https://feeds.bloomberg.com/markets/news.rss"),
@@ -82,7 +87,6 @@ FEEDS: list[tuple[str, str]] = [
     ("The Guardian World", "https://www.theguardian.com/world/rss"),
     ("NPR World", "https://feeds.npr.org/1004/rss.xml"),
     ("Foreign Policy", "https://foreignpolicy.com/feed/"),
-    ("Reuters World", "https://openrss.org/feed/www.reuters.com/world"),
     ("The Intercept", "https://theintercept.com/feed/?rss"),
     # ── Health & Medicine ────────────────────────────────
     ("STAT News", "https://www.statnews.com/feed/"),
@@ -96,7 +100,8 @@ FEEDS: list[tuple[str, str]] = [
     ("ESPN", "https://www.espn.com/espn/rss/news"),
     ("BBC Sport", "http://feeds.bbci.co.uk/sport/rss.xml"),
     ("CBS Sports", "https://www.cbssports.com/rss/headlines/"),
-    ("Sports Illustrated", "https://www.si.com/rss/si_topstories.rss"),
+    # SI moved the feed; old /rss/si_topstories.rss was 404.
+    ("Sports Illustrated", "https://www.si.com/feed"),
     # ── Entertainment (out-of-scope for civic-literacy mechanics) ──
     ("Variety", "https://variety.com/feed/"),
     ("The Hollywood Reporter", "https://www.hollywoodreporter.com/feed/"),


### PR DESCRIPTION
## Summary

Phase 3.F operational hygiene — Railway logs were warning every 30 min on six feeds. Source: sift PR #88 audit.

| Feed | Old URL | Symptom | Action |
| --- | --- | --- | --- |
| AP News | `apnews.com/world-news.rss` | HTTP 404 | **Drop** |
| Reuters | `openrss.org/feed/www.reuters.com` | HTTP 429 | **Drop** |
| Reuters Business | `openrss.org/feed/www.reuters.com/business` | HTTP 429 | **Drop** |
| Reuters World | `openrss.org/feed/www.reuters.com/world` | HTTP 429 | **Drop** |
| Sports Illustrated | `si.com/rss/si_topstories.rss` | HTTP 404 | **Fix URL** -> `si.com/feed` |
| Washington Post | `feeds.washingtonpost.com/rss/national` | ~empty (5 items, intermittently 0 on Railway) | **Fix URL** -> `rss/homepage` (~70 items) |

## Why drop AP / Reuters instead of substituting

Both retired public RSS:
- AP: now behind an auth-walled API.
- Reuters: killed RSS in 2020. The `openrss.org` wrapper just started rate-limiting Railway egress (429).

Considered substitutes (all rejected):

- `news.google.com/rss/search?q=site:apnews.com` — laundered URLs (`source_url` resolves to a Google redirector, not `apnews.com`), truncated content (no `media:content` images, snippet-only body) which would weaken embeddings and likely break the cross-outlet content-hash dedup we already do on AP wire copy via NPR/CBS, and Google rate-limits cloud egress too.
- `associated-press.s3-website-us-east-1.amazonaws.com/topnews.xml` (third-party S3 mirror) — currently 404.
- `www.reutersagency.com/feed/` — 404. No native Reuters feed exists in 2026.

The substantive AP / Reuters coverage already arrives via NPR, CBS, USA Today, ABC, BBC, Guardian — all of which run their wires. We lose the AP / Reuters byline display, not the journalism. Comment block has a TODO to revisit if/when we acquire AP API or Reuters Connect access.

## Net change

- **54 -> 50 feeds.** Still inside the `40 <= len(FEEDS) <= 70` guard in `tests/test_rss.py::TestFeedConfig::test_feed_count`.
- General/Wire bucket: 14 -> 12. World: 6 -> 5. Business: 6 -> 5. All categories still healthy.

## Verification

Each replacement URL was probed (HTTP + feedparser):

```
200  94435B  n=90  https://www.si.com/feed
200  82870B  n=71  https://feeds.washingtonpost.com/rss/homepage
```

All 109 tests pass locally.

## Test plan

- [x] `pytest tests/` — 109/109 pass
- [ ] After merge + Railway redeploy: tail one 30-min refresh cycle, confirm no warnings on the six previously-dead feeds
- [ ] Confirm `_scheduled_refresh` still reports "10 categories, 0 errors"

🤖 Generated with [Claude Code](https://claude.com/claude-code)