### PR TITLE
fix(entity-linker): filter article's own source from outlet chips

### DIFF
--- a/scripts/backfill_entity_links.py
+++ b/scripts/backfill_entity_links.py
@@ -74,7 +74,8 @@ async def main(dry_run: bool) -> None:
         # policy.
         rows = await conn.fetch(
             """
-            SELECT id, title, summary, source_url, entity_links::text AS el
+            SELECT id, title, summary, source_url, source_name,
+                   entity_links::text AS el
             FROM articles
             WHERE entity_links IS NOT NULL
               AND entity_links::text != '[]'
@@ -87,9 +88,11 @@ async def main(dry_run: bool) -> None:
 
         # Run the LLM linker over all of them at once — concurrency-limited
         # internally; prompt-cache amortizes the catalog tokens across calls.
+        # `source_name` lets the linker drop a self-referencing outlet chip
+        # (e.g., FT article → no Financial Times chip).
         articles = [
-            {"source_url": r["source_url"], "title": r["title"] or "",
-             "summary": r["summary"] or ""}
+            {"source_url": r["source_url"], "source_name": r["source_name"],
+             "title": r["title"] or "", "summary": r["summary"] or ""}
             for r in rows
         ]
         link_map = await link_articles_llm(articles, catalog)  # type: ignore[arg-type]

--- a/services/entity_linker_llm.py
+++ b/services/entity_linker_llm.py
@@ -152,14 +152,68 @@ def _build_system_prompt(catalog: list[CatalogEntry]) -> str:
     return SYSTEM_INSTRUCTIONS.format(catalog=_format_catalog_block(catalog))
 
 
-def _build_user_prompt(title: str, summary: str) -> str:
+def _build_user_prompt(
+    title: str,
+    summary: str,
+    source_name: str | None = None,
+) -> str:
     title = (title or "").strip() or "(untitled)"
     summary = (summary or "").strip() or "(no summary)"
-    return (
-        f"Article title: {title}\n\n"
-        f"Article summary: {summary}\n\n"
-        "Return the JSON array now."
-    )
+    parts = [
+        f"Article title: {title}",
+        f"Article summary: {summary}",
+    ]
+    if source_name:
+        # Belt: tell the LLM the article's own source so it can skip
+        # tagging that outlet (we surface the source separately in the
+        # UI, so a self-referencing chip is just visual noise).
+        parts.append(
+            f"Article source: {source_name}\n\n"
+            "Do NOT tag the article's own source as an outlet entity. "
+            "If the source above matches one of the OUTLETS in the roster, "
+            "skip that tag — it's surfaced elsewhere in the UI."
+        )
+    parts.append("Return the JSON array now.")
+    return "\n\n".join(parts)
+
+
+# ── Source-name → outlet-slug resolution ──────────────────────────
+
+
+def _normalize_outlet_name(name: str) -> str:
+    """Lowercase + strip a leading 'the ' for forgiving matches.
+
+    'The New York Times' and 'New York Times' should map to the same
+    outlet. Common abbreviations (FT, WSJ, NPR) aren't handled here —
+    those would need explicit aliases on outlet_profiles.
+    """
+    n = name.strip().lower()
+    if n.startswith("the "):
+        n = n[4:]
+    return n
+
+
+def _build_outlet_name_index(catalog: list["CatalogEntry"]) -> dict[str, str]:
+    """{normalized_outlet_name: slug}. Used to resolve an article's raw
+    `source_name` to a curated outlet slug for the self-reference filter.
+    """
+    out: dict[str, str] = {}
+    for row in catalog:
+        if row["type"] == "outlet":
+            out[_normalize_outlet_name(row["primary_name"])] = row["canonical_id"]
+    return out
+
+
+def _resolve_source_outlet_slug(
+    source_name: str | None,
+    name_index: dict[str, str],
+) -> str | None:
+    """Best-effort resolution of `source_name` to an outlet slug.
+    Returns None on no match — the filter then becomes a no-op.
+    """
+    if not source_name:
+        return None
+    return name_index.get(_normalize_outlet_name(source_name))
 
 
 # ── Response parsing ───────────────────────────────────────────────
@@ -195,10 +249,14 @@ def _extract_json_array(text: str) -> list[dict] | None:
 def _parse_response(
     text: str,
     valid_canonicals: dict[str, set[str]],
+    *,
+    source_outlet_slug: str | None = None,
 ) -> list[EntityLink]:
     """Validate parsed entries against the catalog. Drops anything the
     model hallucinated (wrong type, unknown canonical_id, missing
-    surface_form)."""
+    surface_form). Also drops a self-referencing outlet chip when the
+    LLM tags the article's own source — `source_outlet_slug` is the
+    suspenders behind the prompt's belt rule."""
     parsed = _extract_json_array(text)
     if parsed is None:
         return []
@@ -220,6 +278,10 @@ def _parse_response(
         cid = cid.strip()
         # Reject hallucinations: the model must pick from the actual roster.
         if cid not in valid_canonicals.get(etype, set()):
+            continue
+        # Suspenders: drop a self-referencing outlet chip even if the LLM
+        # ignored the prompt rule.
+        if etype == "outlet" and source_outlet_slug and cid == source_outlet_slug:
             continue
         ref = (etype, cid)
         if ref in seen:
@@ -255,9 +317,16 @@ async def link_text_llm(
     summary: str,
     catalog: list[CatalogEntry],
     *,
+    source_name: str | None = None,
     client: anthropic.AsyncAnthropic | None = None,
 ) -> list[EntityLink]:
     """Single-article entity linking via Claude.
+
+    `source_name` is the article's own source (e.g., "Reuters",
+    "Financial Times"). When provided, we resolve it to an outlet slug
+    via the catalog and (a) tell the LLM in the prompt to skip tagging
+    that outlet, and (b) drop self-referencing outlet chips in
+    post-processing as a backstop.
 
     Returns [] on any failure path (API error, parse error, timeout).
     The caller is responsible for falling back to the regex linker if
@@ -269,8 +338,11 @@ async def link_text_llm(
 
     client = client or _client()
     system_prompt = _build_system_prompt(catalog)
-    user_prompt = _build_user_prompt(title, summary)
+    user_prompt = _build_user_prompt(title, summary, source_name=source_name)
     valid = _index_catalog(catalog)
+    source_slug = _resolve_source_outlet_slug(
+        source_name, _build_outlet_name_index(catalog),
+    )
 
     try:
         response = await asyncio.wait_for(
@@ -300,7 +372,7 @@ async def link_text_llm(
     log_usage("entity_linker_llm.link_text", response, model=MODEL)
 
     text = "".join(b.text for b in response.content if b.type == "text")
-    return _parse_response(text, valid)
+    return _parse_response(text, valid, source_outlet_slug=source_slug)
 
 
 async def link_articles_llm(
@@ -330,6 +402,7 @@ async def link_articles_llm(
                 article.get("title") or "",
                 article.get("summary") or "",
                 catalog,
+                source_name=article.get("source_name") or None,
                 client=client,
             )
             return url, links

--- a/tests/test_entity_linker_llm.py
+++ b/tests/test_entity_linker_llm.py
@@ -12,12 +12,15 @@ from unittest.mock import AsyncMock
 import pytest
 
 from services.entity_linker_llm import (
+    _build_outlet_name_index,
     _build_system_prompt,
     _build_user_prompt,
     _extract_json_array,
     _format_catalog_block,
     _index_catalog,
+    _normalize_outlet_name,
     _parse_response,
+    _resolve_source_outlet_slug,
     link_text_llm,
 )
 
@@ -96,6 +99,95 @@ def test_build_user_prompt_handles_empty_fields():
     p = _build_user_prompt("", "")
     assert "(untitled)" in p
     assert "(no summary)" in p
+
+
+def test_build_user_prompt_with_source_includes_self_skip_rule():
+    """When source_name is present, tell the LLM to skip the self-source."""
+    p = _build_user_prompt(
+        "Some headline", "Some summary", source_name="Financial Times",
+    )
+    assert "Financial Times" in p
+    assert "Do NOT tag the article's own source" in p
+
+
+def test_build_user_prompt_without_source_omits_self_skip_rule():
+    """No source_name → no self-skip clause (keeps the prompt lean)."""
+    p = _build_user_prompt("Some headline", "Some summary")
+    assert "Do NOT tag the article's own source" not in p
+
+
+# ── Source-outlet resolution ──────────────────────────────────────
+
+
+def test_normalize_outlet_name_strips_leading_the():
+    assert _normalize_outlet_name("The New York Times") == "new york times"
+    assert _normalize_outlet_name("New York Times") == "new york times"
+
+
+def test_normalize_outlet_name_lowercases():
+    assert _normalize_outlet_name("Reuters") == "reuters"
+    assert _normalize_outlet_name("REUTERS") == "reuters"
+
+
+def test_build_outlet_name_index_only_outlets():
+    """Politicians/orgs/bills don't pollute the outlet name lookup."""
+    idx = _build_outlet_name_index(SAMPLE_CATALOG)
+    assert idx == {"reuters": "reuters"}
+
+
+def test_resolve_source_outlet_slug_match():
+    idx = _build_outlet_name_index(SAMPLE_CATALOG)
+    assert _resolve_source_outlet_slug("Reuters", idx) == "reuters"
+    # 'The Reuters' would be unusual, but if it happened, match still works.
+    assert _resolve_source_outlet_slug("The Reuters", idx) == "reuters"
+
+
+def test_resolve_source_outlet_slug_no_match():
+    idx = _build_outlet_name_index(SAMPLE_CATALOG)
+    assert _resolve_source_outlet_slug("Unknown Outlet", idx) is None
+    assert _resolve_source_outlet_slug(None, idx) is None
+    assert _resolve_source_outlet_slug("", idx) is None
+
+
+# ── Self-source filter in _parse_response ────────────────────────
+
+
+def test_parse_response_drops_self_source_outlet_chip():
+    """LLM tagged the article's own source as an outlet → drop it."""
+    valid = _index_catalog(SAMPLE_CATALOG)
+    text = (
+        '[{"type":"outlet","canonical_id":"reuters","surface_form":"Reuters"},'
+        '{"type":"politician","canonical_id":"S000148","surface_form":"Chuck Schumer"}]'
+    )
+    out = _parse_response(text, valid, source_outlet_slug="reuters")
+    canonicals = {(e["type"], e["canonical_id"]) for e in out}
+    # Outlet chip dropped; politician chip kept.
+    assert canonicals == {("politician", "S000148")}
+
+
+def test_parse_response_keeps_other_outlet_chip_when_filtering_self():
+    """Filtering only drops the self-source, not all outlets."""
+    catalog = SAMPLE_CATALOG + [{
+        "type": "outlet", "canonical_id": "bbc",
+        "primary_name": "BBC", "aliases": [],
+    }]
+    valid = _index_catalog(catalog)
+    text = (
+        '[{"type":"outlet","canonical_id":"reuters","surface_form":"Reuters"},'
+        '{"type":"outlet","canonical_id":"bbc","surface_form":"BBC"}]'
+    )
+    out = _parse_response(text, valid, source_outlet_slug="reuters")
+    canonicals = {e["canonical_id"] for e in out}
+    assert canonicals == {"bbc"}
+
+
+def test_parse_response_no_filter_when_source_slug_none():
+    """No source_slug → all valid outlet chips pass through."""
+    valid = _index_catalog(SAMPLE_CATALOG)
+    text = '[{"type":"outlet","canonical_id":"reuters","surface_form":"Reuters"}]'
+    out = _parse_response(text, valid, source_outlet_slug=None)
+    assert len(out) == 1
+    assert out[0]["canonical_id"] == "reuters"
 
 
 # ── JSON extraction ────────────────────────────────────────────────
@@ -290,3 +382,38 @@ async def test_link_text_llm_short_circuits_on_empty_catalog():
         catalog=[],
     )
     assert out == []
+
+
+@pytest.mark.asyncio
+async def test_link_text_llm_filters_self_source_outlet_end_to_end(monkeypatch):
+    """Even if the LLM tags the article's own source, the post-filter
+    drops it. Belt-and-suspenders: prompt asks the LLM to skip,
+    validator drops if the LLM ignored the rule."""
+    monkeypatch.setattr(
+        "services.entity_linker_llm.log_usage", lambda *a, **kw: None,
+    )
+
+    fake_client = SimpleNamespace(
+        messages=SimpleNamespace(
+            create=AsyncMock(return_value=_mock_response(
+                # LLM "ignored" the self-skip rule and tagged Reuters.
+                '[{"type":"outlet","canonical_id":"reuters","surface_form":"Reuters"}]'
+            ))
+        )
+    )
+
+    out = await link_text_llm(
+        title="Some headline",
+        summary="Some summary text.",
+        catalog=SAMPLE_CATALOG,
+        source_name="Reuters",
+        client=fake_client,  # type: ignore[arg-type]
+    )
+    # Self-source chip dropped by the suspenders filter.
+    assert out == []
+
+    # And the prompt told the LLM about it (the belt).
+    args, kwargs = fake_client.messages.create.call_args
+    user_msg = kwargs["messages"][0]["content"]
+    assert "Reuters" in user_msg
+    assert "Do NOT tag the article's own source" in user_msg

--- a/workflows/pipeline_workflow.py
+++ b/workflows/pipeline_workflow.py
@@ -261,12 +261,15 @@ async def link_entities_node(state: PipelineState) -> dict:
     if not new_articles:
         return {"entity_links": {}}
 
-    # Build the article shape the linker expects.
+    # Build the article shape the linker expects. `source_name` lets the
+    # LLM linker drop a self-referencing outlet chip (so an FT article
+    # doesn't get a Financial Times chip).
     inputs = []
     for a in new_articles:
         result = state.get("summaries", {}).get(a.source_url, {})
         inputs.append({
             "source_url": a.source_url,
+            "source_name": a.source_name,
             "title": a.title,
             "summary": result.get("summary", "") if result else "",
         })


### PR DESCRIPTION
## Summary
Followup to #44. With the LLM linker live, outlet chips started appearing on article cards — but the LLM was tagging an article's OWN source as an outlet chip:

- FT chip on a Financial Times article
- Slate chip on a Slate article
- CBS chip on a CBS-published Survivor recap

The chip points back to the article's own outlet dossier, which is already shown separately in the card chrome. It's visual noise + a self-reference that adds nothing.

## Belt-and-suspenders fix

**Belt (prompt):** when \`source_name\` is supplied, the user prompt includes it and asks Claude to skip tagging that outlet.

**Suspenders (validator):** \`_parse_response\` accepts an optional \`source_outlet_slug\`; any outlet chip whose \`canonical_id\` matches gets dropped after the LLM responds. So even if the LLM ignores the prompt rule, the chip never makes it through.

## Source-name → slug resolution

Case-insensitive match against \`outlet_profiles.name\`, with a leading \"The \" stripped so \"The New York Times\" and \"New York Times\" map to the same row. Common abbreviations (FT, WSJ, NPR) aren't handled here — those would need explicit aliases on \`outlet_profiles\`, which is a separate feature. On no match, the filter is a no-op (the prompt-side belt is still in effect).

## Wiring
- \`services/entity_linker_llm.py\`: \`link_text_llm\` accepts \`source_name\`; \`link_articles_llm\` reads it from the article dict.
- \`workflows/pipeline_workflow.py\`: passes \`a.source_name\` through (was being dropped).
- \`scripts/backfill_entity_links.py\`: pulls \`source_name\` and passes it through so the cleanup script exercises the same path.

## Tests
**+11 cases (54 total):** prompt assembly with/without source, outlet name normalization (lowercase + leading \"The \" stripping), outlet-name index, slug resolution (match / no-match / None), self-source filter in \`_parse_response\` (single outlet, multi-outlet), and end-to-end with mocked Anthropic asserting both belt (prompt has self-skip rule) and suspenders (post-filter drops if LLM ignores).

## After merge
Re-run \`scripts/backfill_entity_links.py\` once. Expected: FT chip drops off the FT-published article, CBS chip drops off the CBS-published Survivor recap, Slate chip drops off the Slate-published Slow Burn piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)