### PR TITLE
fix(entity-linker-llm): reject state/party/chamber-only politician matches

### DIFF
--- a/services/entity_linker_llm.py
+++ b/services/entity_linker_llm.py
@@ -134,14 +134,26 @@ refer to the Senator from Maine OR the Boston Fed President. Use article \
 context (titles, organizations, locations, roles) to decide which person \
 is meant. If unclear, omit the tag.
 
-3. Tag an outlet only when its name appears in the article copy AND \
+3. Require a DIRECT reference. Do NOT tag a politician based on indirect \
+signals such as a state name, party label, or chamber alone. The article \
+must name the person directly (full name, or a clearly resolvable form like \
+"Speaker Johnson", "Sen. Schumer", or "the Senator from Vermont, Sanders"). \
+Examples of references that must NOT produce a politician tag:
+   - "blue states aren't getting fire prevention money" (mentioning Colorado \
+     or California is not a tag of any senator from those states)
+   - "California Republicans face primaries" (a state's politicians are not \
+     individually named here)
+   - "Democrats blocked the bill" (no specific politician is named)
+   - "Maryland lawmakers demanded answers" (collective; not a single politician)
+
+4. Tag an outlet only when its name appears in the article copy AND \
 refers to that outlet's reporting (e.g., "according to Reuters"). Don't \
 tag the article's own source — that's surfaced separately.
 
-4. surface_form must be the exact substring as it appears in the article \
+5. surface_form must be the exact substring as it appears in the article \
 (preserve original casing).
 
-5. Output JSON only — no prose, no markdown fences. Empty array if no \
+6. Output JSON only — no prose, no markdown fences. Empty array if no \
 roster entities are mentioned.
 
 Schema:

--- a/tests/test_entity_linker_llm.py
+++ b/tests/test_entity_linker_llm.py
@@ -94,6 +94,20 @@ def test_build_system_prompt_embeds_catalog():
     assert "Susan Collins" in p
 
 
+def test_build_system_prompt_includes_indirect_reference_guard():
+    """Rule 3 — politician tags require a DIRECT reference, not just a
+    state name, party label, or chamber. Caught these in prod after PR
+    #45 backfill: 'Colorado' → senator Bennet, 'California' → Pelosi
+    on a 'blue states aren't getting fire prevention money' article.
+    """
+    p = _build_system_prompt(SAMPLE_CATALOG)
+    assert "DIRECT reference" in p
+    # Specific examples should appear so Claude has anchors.
+    assert "blue states" in p.lower()
+    assert "lawmakers demanded" in p.lower()
+    assert "state name" in p.lower()
+
+
 def test_build_user_prompt_handles_empty_fields():
     """Falls back to placeholders rather than blank prompt."""
     p = _build_user_prompt("", "")


### PR DESCRIPTION
## Summary
Follow-up on PR #45 (self-source filter) caught a new false-positive pattern from the LLM linker: **indirect references that aren't named politicians**, but the model was eagerly tagging anyway.

## Live examples seen in prod backfill
| Article | Bad chip | Why wrong |
|---|---|---|
| "These blue states aren't getting fire prevention money" | Colorado → Sen. Michael Bennet, California → CA politician | State name ≠ a specific politician |
| "Lawmakers demand answers after 32K gallons of jet fuel leaks" | "Maryland lawmakers" → some D-MD politician | Collective, not a person |
| "California Republicans race to the right" | CA Republicans → some R-CA member | State + party isn't a person |

With ~600 entries in the catalog, the LLM was reaching for state-anchored matches without a direct mention.

## Fix
Add **Rule 3** to the system prompt:

> 3. Require a DIRECT reference. Do NOT tag a politician based on indirect signals such as a state name, party label, or chamber alone. The article must name the person directly (full name, or a clearly resolvable form like "Speaker Johnson", "Sen. Schumer", or "the Senator from Vermont, Sanders").

With 4 anti-pattern examples Claude can anchor on:
- "blue states aren't getting fire prevention money"
- "California Republicans face primaries"
- "Democrats blocked the bill"
- "Maryland lawmakers demanded answers"

## Live verification
Already ran the backfill against prod with the new prompt:
\`\`\`
State-name surface forms in chips:    0 (was several)
"blue states aren't getting" article: cleared to [] ✓
"Lawmakers demand answers" article:   cleared to [] ✓
"California Republicans" article:     refreshed without state-anchored tags ✓
\`\`\`

## Residual edge case (out of scope)
Article directly names a private individual ("Kayla McClellan, a local teacher") who happens to share a surname with a Congressmember in the roster. The new rule doesn't catch this — the direct-reference requirement is technically satisfied. Would need either context cues ("teacher" → not the politician) or per-name handling. Rare in practice; leaving as a known limitation.

## Test plan
- [x] \`npx pytest\` — 55 pass (+1 new test verifying the rule + 3 anti-pattern anchors are in the system prompt)
- [x] Live verification against prod (state-name chips → 0)
- [x] CI \`Lint & Test\` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)