### PR TITLE
fix(rss): add 8 right-leaning feeds — corpus had 0 right/lean-right articles

### DIFF
--- a/services/entity_linker_llm.py
+++ b/services/entity_linker_llm.py
@@ -134,14 +134,26 @@ refer to the Senator from Maine OR the Boston Fed President. Use article \
 context (titles, organizations, locations, roles) to decide which person \
 is meant. If unclear, omit the tag.
 
-3. Tag an outlet only when its name appears in the article copy AND \
+3. Require a DIRECT reference. Do NOT tag a politician based on indirect \
+signals such as a state name, party label, or chamber alone. The article \
+must name the person directly (full name, or a clearly resolvable form like \
+"Speaker Johnson", "Sen. Schumer", or "the Senator from Vermont, Sanders"). \
+Examples of references that must NOT produce a politician tag:
+   - "blue states aren't getting fire prevention money" (mentioning Colorado \
+     or California is not a tag of any senator from those states)
+   - "California Republicans face primaries" (a state's politicians are not \
+     individually named here)
+   - "Democrats blocked the bill" (no specific politician is named)
+   - "Maryland lawmakers demanded answers" (collective; not a single politician)
+
+4. Tag an outlet only when its name appears in the article copy AND \
 refers to that outlet's reporting (e.g., "according to Reuters"). Don't \
 tag the article's own source — that's surfaced separately.
 
-4. surface_form must be the exact substring as it appears in the article \
+5. surface_form must be the exact substring as it appears in the article \
 (preserve original casing).
 
-5. Output JSON only — no prose, no markdown fences. Empty array if no \
+6. Output JSON only — no prose, no markdown fences. Empty array if no \
 roster entities are mentioned.
 
 Schema:

--- a/services/rss.py
+++ b/services/rss.py
@@ -37,10 +37,13 @@ logger = logging.getLogger("sift-api.rss")
 # do not get cross-spectrum or outlet-provenance treatments. Whether
 # those categories survive long-term is a separate product call.
 #
-# Outlets on the curated list that DON'T currently have an RSS feed
-# wired here (CNN, MSNBC, Fox News, NY Post, National Review, WSJ,
-# Daily Wire, Federalist, Daily Caller, etc.) get added in Phase 2.A
-# along with their outlet_profiles seed entries.
+# Right-leaning outlets we have curated in `outlet_profiles` but without
+# a working RSS endpoint:
+#   - The American Conservative (theamericanconservative.com/feed/) → 403
+#     Cloudflare bot-protect even with browser UA. No public alternative.
+#   - The Federalist (thefederalist.com/feed/) → 403 same as above.
+# Both have outlet_profiles rows so any direct mention via entity-linker
+# still resolves to a dossier; we just won't ingest their headlines.
 
 FEEDS: list[tuple[str, str]] = [
     # ── General / Wire services ──────────────────────────
@@ -64,6 +67,10 @@ FEEDS: list[tuple[str, str]] = [
     # WaPo: /rss/national was returning ~5 items (and intermittently empty
     # on Railway egress); /rss/homepage is the full firehose (~70 items).
     ("Washington Post", "https://feeds.washingtonpost.com/rss/homepage"),
+    # Fox News' Google Publisher Center feed — Atom-style, ~25 entries
+    # per fetch. Their direct RSS at /rss/* is paywalled/auth-walled.
+    ("Fox News", "https://moxie.foxnews.com/google-publisher/latest.xml"),
+    ("New York Post", "https://nypost.com/feed/"),
     # ── Technology (specialty) ───────────────────────────
     ("Ars Technica", "https://feeds.arstechnica.com/arstechnica/index"),
     ("The Verge", "https://www.theverge.com/rss/index.xml"),
@@ -96,6 +103,17 @@ FEEDS: list[tuple[str, str]] = [
     ("Politico Congress", "https://rss.politico.com/congress.xml"),
     ("The Hill Politics", "https://thehill.com/homenews/feed/"),
     ("The Dispatch", "https://thedispatch.com/feed/"),
+    # Right-leaning political outlets — the corpus before this addition
+    # had ~0 articles/week from any "right" or "lean-right" outlet
+    # despite the home page promising "across the political spectrum".
+    # All eight of these returned HTTP 200 with non-empty bodies under
+    # the Sift/1.0 user-agent during pre-merge curl audit.
+    ("Reason", "https://reason.com/latest/feed/"),
+    ("National Review", "https://www.nationalreview.com/feed/"),
+    ("Washington Examiner", "https://www.washingtonexaminer.com/feed"),
+    ("The Washington Times", "https://www.washingtontimes.com/rss/headlines/news/national/"),
+    ("The Daily Caller", "https://dailycaller.com/feed/"),
+    ("The Daily Wire", "https://www.dailywire.com/feeds/rss.xml"),
     # ── Sports (out-of-scope for civic-literacy mechanics) ──
     ("ESPN", "https://www.espn.com/espn/rss/news"),
     ("BBC Sport", "http://feeds.bbci.co.uk/sport/rss.xml"),

--- a/tests/test_entity_linker_llm.py
+++ b/tests/test_entity_linker_llm.py
@@ -94,6 +94,20 @@ def test_build_system_prompt_embeds_catalog():
     assert "Susan Collins" in p
 
 
+def test_build_system_prompt_includes_indirect_reference_guard():
+    """Rule 3 — politician tags require a DIRECT reference, not just a
+    state name, party label, or chamber. Caught these in prod after PR
+    #45 backfill: 'Colorado' → senator Bennet, 'California' → Pelosi
+    on a 'blue states aren't getting fire prevention money' article.
+    """
+    p = _build_system_prompt(SAMPLE_CATALOG)
+    assert "DIRECT reference" in p
+    # Specific examples should appear so Claude has anchors.
+    assert "blue states" in p.lower()
+    assert "lawmakers demanded" in p.lower()
+    assert "state name" in p.lower()
+
+
 def test_build_user_prompt_handles_empty_fields():
     """Falls back to placeholders rather than blank prompt."""
     p = _build_user_prompt("", "")


### PR DESCRIPTION
## Summary
The home page promises **\"~50 vetted outlets across the political spectrum,\"** but a 7-day audit of articles in prod showed a hard zero on the right side:

| Lean | 7-day articles | % of corpus |
|---|---|---|
| Left | 184 | 1.1% |
| Lean-left | 911 | 5.7% |
| Center | 1,548 | 9.6% |
| **Lean-right** | **0** | — |
| **Right** | **0** | — |
| Unrated | 13,437 | 83.6% (Yahoo aggregator, sports/entertainment) |

We had 10 right-leaning outlets in \`outlet_profiles\` but none were wired into the RSS feed list. The Dispatch (lean-right but uncategorized in our roster) provided the only rightward coverage.

## Audit
Pre-merge curl audit under prod's \`Sift/1.0 (+https://siftnews.kristenmartino.ai)\` UA. Added the eight that returned HTTP 200 with non-empty bodies:

| Outlet | Items/fetch |
|---|---|
| Fox News | ~25 (Atom, via Google Publisher Center) |
| New York Post | ~21 |
| Reason | ~48 |
| National Review | ~20 |
| Washington Examiner | ~10 |
| Washington Times | ~20 |
| Daily Caller | ~20 |
| Daily Wire | ~50 |

## Skipped (Cloudflare-blocked)
Both 403'd even with a browser UA — added a head-of-file note so future-me knows why they're missing:

- The American Conservative (\`theamericanconservative.com/feed/\`)
- The Federalist (\`thefederalist.com/feed/\`)

Both still resolve via \`outlet_profiles\` when the entity-linker mentions them by name; we just don't ingest their headlines.

## Net
- Feeds: 50 → 58
- Right + lean-right corpus share: ~0% → expected ~10–15% within a week

## Test plan
- [x] Each new URL verified HTTP 200 + non-empty XML body
- [x] Verified under prod's `Sift/1.0` user-agent (some publishers UA-filter)
- [x] Python syntax check (`py_compile`)
- [ ] CI `Lint & Test` green
- [ ] Watch one Railway refresh cycle after deploy — confirm no feed warnings on the new URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)