### PR TITLE
feat(search): Phase 1 — search_queries instrumentation table

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -233,6 +233,48 @@ async def _apply_migrations(pool: asyncpg.Pool) -> None:
             "ON articles USING gin(entity_links)"
         )
 
+        # Search-funnel instrumentation (migrations/009_search_queries.sql).
+        # Phase 1 of search-improvement plan: log every topic-search query
+        # so we can see what users actually look for and decide whether
+        # the next investment should be entity-aware resolution (Phase 2)
+        # or HNSW + re-ranking (Phase 3). Raw IPs are never persisted —
+        # the sift route hashes them with HMAC-SHA256 before INSERT.
+        # 90-day retention enforced by scripts/cleanup_old_search_queries.py.
+        await conn.execute(
+            "CREATE EXTENSION IF NOT EXISTS pgcrypto"
+        )
+        await conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS search_queries (
+              id                      TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+              created_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+              query                   TEXT NOT NULL,
+              query_norm              TEXT NOT NULL,
+              query_token_count       INT NOT NULL,
+              result_count_vector     INT NOT NULL,
+              result_count_total      INT NOT NULL,
+              fallback_used           BOOLEAN NOT NULL DEFAULT FALSE,
+              latency_ms_total        INT NOT NULL,
+              latency_ms_embed        INT,
+              latency_ms_vector       INT,
+              latency_ms_fallback     INT,
+              session_id              TEXT,
+              ip_hash                 TEXT,
+              user_agent_class        TEXT,
+              matched_entity_type     TEXT,
+              matched_entity_id       TEXT
+            )
+            """
+        )
+        await conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_search_queries_created "
+            "ON search_queries(created_at DESC)"
+        )
+        await conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_search_queries_query_norm "
+            "ON search_queries(query_norm)"
+        )
+
 
 async def get_pool() -> asyncpg.Pool:
     if _pool is None:

--- a/init.sql
+++ b/init.sql
@@ -126,3 +126,36 @@ CREATE TABLE IF NOT EXISTS api_batches (
 
 CREATE INDEX IF NOT EXISTS idx_api_batches_status_kind
     ON api_batches(status, kind);
+
+-- Search-funnel instrumentation (migrations/009_search_queries.sql).
+-- Phase 1 of search-improvement plan: one row per topic-search request
+-- so we can see what users actually look for. Raw IPs are NEVER stored —
+-- the sift route hashes them with HMAC-SHA256 before INSERT. Query text
+-- is verbatim (needed for top-query rollups + eval-set generation);
+-- 90-day retention enforced by scripts/cleanup_old_search_queries.py.
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS search_queries (
+    id                      TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+    created_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    query                   TEXT NOT NULL,             -- raw, max 200 chars per route guard
+    query_norm              TEXT NOT NULL,             -- lowercased, whitespace-collapsed
+    query_token_count       INT NOT NULL,              -- proxy for "name" vs "question"
+    result_count_vector     INT NOT NULL,              -- passed SIMILARITY_THRESHOLD
+    result_count_total      INT NOT NULL,              -- after web-fallback dedup
+    fallback_used           BOOLEAN NOT NULL DEFAULT FALSE,
+    latency_ms_total        INT NOT NULL,
+    latency_ms_embed        INT,
+    latency_ms_vector       INT,
+    latency_ms_fallback     INT,                       -- null when fallback not used
+    session_id              TEXT,                      -- localStorage UUID
+    ip_hash                 TEXT,                      -- HMAC-SHA256, never raw
+    user_agent_class        TEXT,                      -- mobile|desktop|bot|unknown
+    matched_entity_type     TEXT,                      -- Phase 2 hook: politician|org|bill|outlet
+    matched_entity_id       TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_search_queries_created
+    ON search_queries(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_search_queries_query_norm
+    ON search_queries(query_norm);

--- a/migrations/009_search_queries.sql
+++ b/migrations/009_search_queries.sql
@@ -1,0 +1,56 @@
+-- Phase 1 search-funnel instrumentation.
+--
+-- One row per search request. The Next.js topic-search route writes
+-- here at end-of-stream (fire-and-forget). Goal: enough signal in
+-- 7-14 days to decide whether the next search investment goes into
+-- (a) entity-aware resolution (Phase 2) or (b) HNSW + re-ranking
+-- (Phase 3). See sift PR for the matching INSERT logic.
+--
+-- Privacy posture:
+--   - Raw IPs are NEVER persisted. `ip_hash` is HMAC-SHA256(ip, SECRET).
+--   - Query text IS stored verbatim — necessary to find top queries
+--     and to build a real eval set. Retention is capped at 90 days
+--     via scripts/cleanup_old_search_queries.py (run periodically).
+--   - Session id is a localStorage UUID set client-side; not tied to
+--     Clerk auth, not a tracking cookie.
+--
+-- NOTE: CREATE INDEX CONCURRENTLY cannot run inside a transaction
+-- block. The app-startup migration path in app/db.py applies the same
+-- DDL without CONCURRENTLY (idempotent via IF NOT EXISTS); operators
+-- applying this file manually should comment out CONCURRENTLY or use
+-- psql with one-statement-per-call.
+--
+-- pgcrypto provides gen_random_uuid() for the row id default — most
+-- Neon projects already have it; CREATE EXTENSION IF NOT EXISTS is a
+-- no-op when present.
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS search_queries (
+  id                      TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+  created_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  query                   TEXT NOT NULL,                      -- raw, max 200 chars per route guard
+  query_norm              TEXT NOT NULL,                      -- lowercased, whitespace-collapsed
+  query_token_count       INT NOT NULL,                       -- proxy for "name" vs "question"
+  result_count_vector     INT NOT NULL,                       -- passed SIMILARITY_THRESHOLD
+  result_count_total      INT NOT NULL,                       -- after web-fallback dedup
+  fallback_used           BOOLEAN NOT NULL DEFAULT FALSE,
+  latency_ms_total        INT NOT NULL,
+  latency_ms_embed        INT,
+  latency_ms_vector       INT,
+  latency_ms_fallback     INT,                                -- null when fallback not used
+  session_id              TEXT,
+  ip_hash                 TEXT,                               -- HMAC-SHA256, never raw
+  user_agent_class        TEXT,                               -- mobile|desktop|bot|unknown
+  -- Phase 2 hooks — null today; populated when entity-aware search ships.
+  matched_entity_type     TEXT,                               -- politician|org|bill|outlet
+  matched_entity_id       TEXT
+);
+
+-- Time-ordered scan for "queries in the last N days" aggregations.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_search_queries_created
+  ON search_queries(created_at DESC);
+
+-- Top-query rollups (GROUP BY query_norm).
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_search_queries_query_norm
+  ON search_queries(query_norm);

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -18,6 +18,7 @@ One-off and diagnostic scripts. All run from the `sift-api/` root and use
 | `seed_bill_profiles.py`         | **Yes**       | No           | UPSERTs `bill_profiles` from `data/bill_profiles.csv`. Idempotent. NULLs out unresolved sponsor_bioguide refs. |
 | `seed_all.sh`                   | **Yes**       | No           | One-shot wrapper: dry-run validates every CSV, then runs all six seeds against prod in order, with a human-review pause before the alias seed. `--dry-run-only` and `--skip-aliases` flags supported. |
 | `backfill_entity_links.py`      | **Yes**       | No           | One-shot: re-runs the Phase 3.G entity linker over articles that already have a non-empty `entity_links` value, writes corrected links back. Used after #40 dropped last-name-only aliases (the policy change cleared 46 of 50 false-positive chips in prod). Idempotent — safe to re-run; `--dry-run` for spot checks. Regex-only, no LLM cost. |
+| `cleanup_old_search_queries.py` | **Yes** (DELETE) | No        | Phase 1 search-analytics retention. DELETEs `search_queries` rows older than 90 days (configurable via `--days N`). The privacy page commits to 90-day retention on logged search queries; this script enforces it. Re-run weekly or wire into a daily Railway cron when query volume warrants. `--dry-run` flag for spot-checks. Safe to re-run. |
 
 ## Running against prod
 

--- a/scripts/cleanup_old_search_queries.py
+++ b/scripts/cleanup_old_search_queries.py
@@ -1,0 +1,87 @@
+"""Enforce 90-day retention on search_queries.
+
+Phase 1 search-funnel instrumentation logs every topic-search request to
+the `search_queries` table for analytics. To honor the 90-day retention
+posture stated in /privacy, this script deletes rows older than 90 days.
+
+Wire into a daily cron / Railway scheduled job once query volume warrants
+auto-cleanup. At MVP volume (<1k rows/day) running once a week is fine.
+
+Run from sift-api root:
+
+    railway run ./.venv/bin/python3 scripts/cleanup_old_search_queries.py
+    railway run ./.venv/bin/python3 scripts/cleanup_old_search_queries.py --dry-run
+    railway run ./.venv/bin/python3 scripts/cleanup_old_search_queries.py --days 60
+
+Re-run-safe. Reports rows deleted and current table size.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import asyncpg  # noqa: E402
+
+DEFAULT_RETENTION_DAYS = 90
+
+
+async def main(days: int, dry_run: bool) -> None:
+    db_url = os.environ.get("DATABASE_URL")
+    if not db_url:
+        print("ERROR: DATABASE_URL not set.", file=sys.stderr)
+        sys.exit(1)
+
+    ssl = "require" if "neon.tech" in db_url else False
+    conn = await asyncpg.connect(db_url, ssl=ssl)
+    try:
+        total_before = await conn.fetchval("SELECT count(*) FROM search_queries")
+        eligible = await conn.fetchval(
+            "SELECT count(*) FROM search_queries "
+            "WHERE created_at < now() - ($1 || ' days')::interval",
+            str(days),
+        )
+        print(f"Rows in search_queries:        {total_before:,}")
+        print(f"Rows older than {days} days:   {eligible:,}")
+
+        if dry_run:
+            print("--dry-run set; no DELETE.")
+            return
+
+        if eligible == 0:
+            print("Nothing to delete.")
+            return
+
+        result = await conn.execute(
+            "DELETE FROM search_queries "
+            "WHERE created_at < now() - ($1 || ' days')::interval",
+            str(days),
+        )
+        # asyncpg returns 'DELETE <n>' as the command tag
+        deleted = int(result.rsplit(" ", 1)[1]) if " " in result else 0
+        total_after = await conn.fetchval("SELECT count(*) FROM search_queries")
+        print(f"Deleted: {deleted:,}")
+        print(f"Rows remaining: {total_after:,}")
+    finally:
+        await conn.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Delete search_queries rows older than --days (default 90).",
+    )
+    parser.add_argument(
+        "--days", type=int, default=DEFAULT_RETENTION_DAYS,
+        help=f"Retention window in days (default {DEFAULT_RETENTION_DAYS}).",
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        asyncio.run(main(days=args.days, dry_run=args.dry_run))
+    except KeyboardInterrupt:
+        print("\nAborted.", file=sys.stderr)
+        sys.exit(130)


### PR DESCRIPTION
## Summary
Phase 1 of the senior-staff search overhaul. Before changing search behavior (HNSW index, entity-aware resolution, re-ranking), we need to know **what users actually search for**.

Two weeks of real logs decide the next investment:
- **Phase 2** (entity-aware resolution) if queries are dominated by short names / acronyms
- **Phase 3** (HNSW + re-ranking) if queries are dominated by long-form topic questions and fallback fires often
- **Corpus expansion** if vector results consistently miss

Right now we're optimizing in the dark. This PR adds the dark-vision gear.

## What lands

### \`search_queries\` table
One row per topic-search request. Columns:

| Column | Notes |
|---|---|
| \`id\` | \`gen_random_uuid()\`, TEXT |
| \`created_at\` | \`NOW()\` default |
| \`query\` / \`query_norm\` | Raw + lowercased/whitespace-collapsed |
| \`query_token_count\` | Proxy for "name" vs "question" |
| \`result_count_vector\` / \`_total\` | Before vs after web-fallback dedup |
| \`fallback_used\` | bool |
| \`latency_ms_total/embed/vector/fallback\` | Per-stage timings |
| \`session_id\` | localStorage UUID, **not** a cookie |
| \`ip_hash\` | **HMAC-SHA256** — raw IP never persisted |
| \`user_agent_class\` | mobile / desktop / bot / unknown |
| \`matched_entity_type\` / \`matched_entity_id\` | Phase 2 hook |

Two indexes:
- \`idx_search_queries_created\` — time-ordered scans for "last N days" rollups
- \`idx_search_queries_query_norm\` — top-query GROUP BY rollups

### Migration in both paths per CLAUDE.md
- \`migrations/009_search_queries.sql\` — operator-facing, CONCURRENTLY
- \`app/db.py:_apply_migrations\` — Railway-deploy path, non-concurrent, IF NOT EXISTS guards

### \`init.sql\` updated for fresh-DB setup

### \`scripts/cleanup_old_search_queries.py\`
Enforces the 90-day retention posture on /privacy. DELETEs rows older than \`--days N\` (default 90). Dry-run flag, idempotent. README row added.

## Privacy posture (explicit)
- **Raw IPs never persisted.** sift companion PR hashes via HMAC-SHA256(ip, SEARCH_IP_SECRET).
- **Query text IS verbatim** — needed for top-query rollups + eval-set generation. 90-day retention cap.
- **session_id** is localStorage UUID — not a tracking cookie, not tied to Clerk auth.
- /privacy page gets a one-line update (companion sift PR).

## Companion sift PR
Actual INSERT logic + privacy copy. Coordinated merge: **this PR first** (table must exist) → sift PR deploys → starts writing.

## Test plan
- [x] Python \`py_compile\` clean
- [x] SQL syntactically valid (verified by eye + structural match to existing migrations)
- [ ] CI \`Lint & Test\` green
- [ ] After deploy: \`railway logs\` shows clean startup migration; \`SELECT count(*) FROM search_queries\` returns 0
- [ ] Companion sift PR merged → first INSERT verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)