### PR TITLE
feat(primer): instrumentation table for panel-expand events (Phase 1)

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -275,6 +275,35 @@ async def _apply_migrations(pool: asyncpg.Pool) -> None:
             "ON search_queries(query_norm)"
         )
 
+        # Primer-expand instrumentation (migrations/010_primer_expand_events.sql).
+        # We've shipped three rounds of primer-content work without ever
+        # knowing whether anyone opens the panel. This table records every
+        # panel-expand click; impressions are NOT tracked (computable from
+        # articles.context_primer IS NOT NULL at query time, no need to
+        # write ~5k rows/day). Privacy posture mirrors search_queries:
+        # IPs hashed, 90-day retention via scripts/cleanup_old_primer_events.py.
+        await conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS primer_expand_events (
+              id                      TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+              created_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+              article_id              TEXT,
+              surface                 TEXT,
+              session_id              TEXT,
+              ip_hash                 TEXT,
+              user_agent_class        TEXT
+            )
+            """
+        )
+        await conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_primer_expand_events_created "
+            "ON primer_expand_events(created_at DESC)"
+        )
+        await conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_primer_expand_events_article "
+            "ON primer_expand_events(article_id) WHERE article_id IS NOT NULL"
+        )
+
 
 async def get_pool() -> asyncpg.Pool:
     if _pool is None:

--- a/init.sql
+++ b/init.sql
@@ -159,3 +159,24 @@ CREATE INDEX IF NOT EXISTS idx_search_queries_created
     ON search_queries(created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_search_queries_query_norm
     ON search_queries(query_norm);
+
+-- Primer-expand instrumentation (migrations/010_primer_expand_events.sql).
+-- Phase 1 question: do users actually open the "What you should know first"
+-- panel? Without this signal, all primer-content iteration is guessing.
+-- Tracks expand clicks only (not impressions — those are computable from
+-- articles.context_primer IS NOT NULL without paying for the writes).
+-- IPs hashed; 90-day retention via scripts/cleanup_old_primer_events.py.
+CREATE TABLE IF NOT EXISTS primer_expand_events (
+    id                      TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+    created_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    article_id              TEXT,             -- nullable: future surfaces may lack one
+    surface                 TEXT,             -- 'feed' | 'bookmarks' | future
+    session_id              TEXT,             -- localStorage UUID
+    ip_hash                 TEXT,             -- HMAC-SHA256, never raw
+    user_agent_class        TEXT              -- mobile|desktop|bot|unknown
+);
+
+CREATE INDEX IF NOT EXISTS idx_primer_expand_events_created
+    ON primer_expand_events(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_primer_expand_events_article
+    ON primer_expand_events(article_id) WHERE article_id IS NOT NULL;

--- a/migrations/010_primer_expand_events.sql
+++ b/migrations/010_primer_expand_events.sql
@@ -1,0 +1,44 @@
+-- Phase 1 primer-expand instrumentation.
+--
+-- After three rounds of work on the "What you should know first" panel
+-- (prompt tightening in PR #48, primer-term dossier links in #90,
+-- agency dossiers + linker upgrades in #91/#46) we still have zero
+-- signal on whether ANYONE opens the panel. The two-options choice
+-- between "keep iterating on primer content" vs "stop and move on"
+-- depends on that one data point.
+--
+-- This table records every panel-expand click. Deliberately NOT tracking
+-- impressions — that would generate ~5k writes/day on data we can
+-- already compute (which articles in the feed have primers from
+-- articles.context_primer IS NOT NULL).
+--
+-- Privacy posture mirrors search_queries (migrations/009):
+--   - Raw IPs are NEVER persisted. `ip_hash` is HMAC-SHA256(ip, SECRET).
+--   - 90-day retention via scripts/cleanup_old_primer_events.py.
+--   - session_id is a localStorage UUID, not a cookie.
+--   - Reuses SEARCH_IP_SECRET (treat it as a general analytics secret).
+--
+-- NOTE: CREATE INDEX CONCURRENTLY cannot run inside a transaction
+-- block. The app-startup migration path in app/db.py applies the same
+-- DDL without CONCURRENTLY (idempotent via IF NOT EXISTS).
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS primer_expand_events (
+  id                      TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+  created_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  article_id              TEXT,                        -- nullable: future surfaces may not have one
+  surface                 TEXT,                        -- 'feed' | 'bookmarks' | future
+  session_id              TEXT,
+  ip_hash                 TEXT,                        -- HMAC-SHA256, never raw
+  user_agent_class        TEXT                         -- mobile|desktop|bot|unknown
+);
+
+-- Time-ordered scan for "last N days" rollups.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_primer_expand_events_created
+  ON primer_expand_events(created_at DESC);
+
+-- Per-article expand counts (which articles' primers get opened most).
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_primer_expand_events_article
+  ON primer_expand_events(article_id)
+  WHERE article_id IS NOT NULL;

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -19,6 +19,7 @@ One-off and diagnostic scripts. All run from the `sift-api/` root and use
 | `seed_all.sh`                   | **Yes**       | No           | One-shot wrapper: dry-run validates every CSV, then runs all six seeds against prod in order, with a human-review pause before the alias seed. `--dry-run-only` and `--skip-aliases` flags supported. |
 | `backfill_entity_links.py`      | **Yes**       | No           | One-shot: re-runs the Phase 3.G entity linker over articles that already have a non-empty `entity_links` value, writes corrected links back. Used after #40 dropped last-name-only aliases (the policy change cleared 46 of 50 false-positive chips in prod). Idempotent — safe to re-run; `--dry-run` for spot checks. Regex-only, no LLM cost. |
 | `cleanup_old_search_queries.py` | **Yes** (DELETE) | No        | Phase 1 search-analytics retention. DELETEs `search_queries` rows older than 90 days (configurable via `--days N`). The privacy page commits to 90-day retention on logged search queries; this script enforces it. Re-run weekly or wire into a daily Railway cron when query volume warrants. `--dry-run` flag for spot-checks. Safe to re-run. |
+| `cleanup_old_primer_events.py`  | **Yes** (DELETE) | No        | Sister to `cleanup_old_search_queries.py` — same shape, same retention promise, different table. DELETEs `primer_expand_events` rows older than 90 days. Run on the same cadence. |
 
 ## Running against prod
 

--- a/scripts/cleanup_old_primer_events.py
+++ b/scripts/cleanup_old_primer_events.py
@@ -1,0 +1,83 @@
+"""Enforce 90-day retention on primer_expand_events.
+
+Sister to scripts/cleanup_old_search_queries.py — same shape, same
+retention promise, different table. Both honor the 90-day commitment
+on /privacy.
+
+Run from sift-api root:
+
+    railway run ./.venv/bin/python3 scripts/cleanup_old_primer_events.py
+    railway run ./.venv/bin/python3 scripts/cleanup_old_primer_events.py --dry-run
+    railway run ./.venv/bin/python3 scripts/cleanup_old_primer_events.py --days 60
+
+Re-run-safe. Reports rows deleted and current table size.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import asyncpg  # noqa: E402
+
+DEFAULT_RETENTION_DAYS = 90
+
+
+async def main(days: int, dry_run: bool) -> None:
+    db_url = os.environ.get("DATABASE_URL")
+    if not db_url:
+        print("ERROR: DATABASE_URL not set.", file=sys.stderr)
+        sys.exit(1)
+
+    ssl = "require" if "neon.tech" in db_url else False
+    conn = await asyncpg.connect(db_url, ssl=ssl)
+    try:
+        total_before = await conn.fetchval("SELECT count(*) FROM primer_expand_events")
+        eligible = await conn.fetchval(
+            "SELECT count(*) FROM primer_expand_events "
+            "WHERE created_at < now() - ($1 || ' days')::interval",
+            str(days),
+        )
+        print(f"Rows in primer_expand_events: {total_before:,}")
+        print(f"Rows older than {days} days:   {eligible:,}")
+
+        if dry_run:
+            print("--dry-run set; no DELETE.")
+            return
+
+        if eligible == 0:
+            print("Nothing to delete.")
+            return
+
+        result = await conn.execute(
+            "DELETE FROM primer_expand_events "
+            "WHERE created_at < now() - ($1 || ' days')::interval",
+            str(days),
+        )
+        deleted = int(result.rsplit(" ", 1)[1]) if " " in result else 0
+        total_after = await conn.fetchval("SELECT count(*) FROM primer_expand_events")
+        print(f"Deleted: {deleted:,}")
+        print(f"Rows remaining: {total_after:,}")
+    finally:
+        await conn.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Delete primer_expand_events rows older than --days (default 90).",
+    )
+    parser.add_argument(
+        "--days", type=int, default=DEFAULT_RETENTION_DAYS,
+        help=f"Retention window in days (default {DEFAULT_RETENTION_DAYS}).",
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        asyncio.run(main(days=args.days, dry_run=args.dry_run))
+    except KeyboardInterrupt:
+        print("\nAborted.", file=sys.stderr)
+        sys.exit(130)


### PR DESCRIPTION
## Summary
After three rounds of primer-content work (prompt tighten in #48, primer-term dossier links in #90, agency dossiers + linker upgrades in #91/#46) we still have **zero signal on whether anyone opens the panel**.

The next decision — "keep iterating on primer content" vs "stop and move on" — depends on one data point: expand rate. Right now we'd be guessing. This PR adds the dark-vision gear.

## Table
\`primer_expand_events\` — one row per panel-expand click. Columns:

| Column | Notes |
|---|---|
| \`id\` | gen_random_uuid(), TEXT |
| \`created_at\` | NOW() default |
| \`article_id\` | nullable — future surfaces may not have one |
| \`surface\` | 'feed' \| 'bookmarks' \| future |
| \`session_id\` | localStorage UUID, not a tracking cookie |
| \`ip_hash\` | **HMAC-SHA256** — raw IP never persisted |
| \`user_agent_class\` | mobile / desktop / bot / unknown |

Two indexes:
- \`idx_primer_expand_events_created\` — time-ordered scans
- \`idx_primer_expand_events_article\` — per-article rollups (partial index, WHERE article_id IS NOT NULL)

## Why expand-only (not impressions)
Impressions are derivable from \`articles.context_primer IS NOT NULL\` at query time — no need to pay for ~5k writes/day on info we already have.

## Migration in both paths per CLAUDE.md
- \`migrations/010_primer_expand_events.sql\` — operator-facing, CONCURRENTLY
- \`app/db.py:_apply_migrations\` — Railway-deploy path, non-concurrent, IF NOT EXISTS guards

## Privacy posture
Mirrors search_queries (#51):
- Raw IPs hashed via HMAC-SHA256 with **shared** \`SEARCH_IP_SECRET\` (treat as general analytics secret)
- 90-day retention via \`scripts/cleanup_old_primer_events.py\`
- session_id is localStorage UUID, not a cookie
- /privacy page gets a line update (companion sift PR)

## Companion sift PR
\`POST /api/primer/expand\`, \`BackgroundPrimer.tsx\` fires on the show-context toggle, privacy copy. **This PR first** (table must exist) → sift PR deploys (starts writing).

## Test plan
- [x] Python \`py_compile\` clean
- [x] SQL syntactically valid (mirrors search_queries shape exactly)
- [ ] CI \`Lint & Test\` green
- [ ] After deploy: \`SELECT count(*) FROM primer_expand_events\` returns 0
- [ ] Companion sift PR merged → first INSERT verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)