### PR TITLE
state-mgmt completion: SessionStart hook + BACKLOG.md + STATUS strategic questions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,17 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
-  "enableAllProjectMcpServers": true
+  "enableAllProjectMcpServers": true,
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "test -f STATUS.md && jq -Rs '{hookSpecificOutput:{hookEventName:\"SessionStart\",additionalContext:.}}' < STATUS.md || echo '{}'",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,0 +1,19 @@
+# sift-api — backlog
+
+Items not committed to a current milestone. Promote to GitHub issues when work is committed; until then, capture here in prose so nothing gets lost.
+
+> **What goes here:** half-formed ideas, deferred features that don't fit a current `tier-*` milestone, quirks worth tracking but not urgent. See [`CLAUDE.md`](CLAUDE.md) for the where-to-file-new-work decision tree.
+
+## Stretch / nice-to-have
+
+- *(Add items here as they surface. Prose, not bullet-perfect — the point is to not lose ideas, not to perfectly organize them.)*
+
+## Bugs / quirks to revisit
+
+- *(Same — add items as you hit them. Tie back to a commit or issue if you can.)*
+
+## Considered and rejected
+
+Architectural alternatives we discussed and chose against. Captured so we don't re-litigate; reasoning is easy to revisit if circumstances change.
+
+- **Canonical `/v1/*` mobile API in sift-api** *(deferred, May 2026)* — proposed in the original iOS plan; the cross-functional assessment correctly pushed back that it's the right move at maturity, not pre-PMF. Reuse Next.js routes for now; collapse later when a second client validates the surface. See `sift/docs/DECISIONS.md#D33` and `sift/docs/IOS_APP_ASSESSMENT.md`.

--- a/STATUS.md
+++ b/STATUS.md
@@ -8,11 +8,35 @@
 
 Civic-literacy pivot backend. Recently shipped: fixed entity linker (LLM-gated, A/B-able) in `services/entity_linker_llm.py`; 170 new dossier entries via 4 new CSVs + seed scripts in `data/` and `scripts/`; `coverage_audit.py` archived measuring post-fix link rate.
 
-## Open strategic question
+## Open strategic questions
 
-**DMCA fair-use posture for AI summarization.**
+Four live unknowns. None block current work; all shape decisions in the next 1–3 months.
 
-Per Railway's 2026 fair-use clause (lists "Hosting/Distribution of DMCA protected content" as prohibited) + the live NYT / Perplexity / AP litigation landscape: audit needed to confirm `services/` doesn't write original article body HTML or images to disk on Railway, and `/methodology` (sibling `sift` repo) needs a transformative-use posture paragraph before any user-submitted-URL features (e.g. iOS share extension) ship. Tracked as a Next-3 item below.
+### 1. When does sift-api need to scale beyond Railway hobby tier?
+
+Pipeline runs every 10 min, ingests ~135 sources, calls Claude for summaries + entity linking + primer generation. Today: comfortably under hobby-tier limits.
+
+Watch for:
+- Pipeline run time exceeds 8 min (close to the 10-min cadence)
+- Anthropic monthly bill from pipeline crosses $50/mo (today: ~$15)
+- Neon Postgres connection pool `max=5` starts queuing requests visibly
+- Native app launches and pushes write volume up
+
+### 2. Is the LLM-based entity linker durable, or does it need a v2?
+
+Phase 3.G.2 shipped the LLM linker with disambiguation rules added since. It's working but it's a moving target — every dossier expansion changes its catalog, and the prompt keeps needing tweaks.
+
+What would resolve this: a stable eval set with target precision/recall numbers, run on every PR that touches `services/entity_linker_llm.py`. Until that exists, the linker stays in "iterate fast" mode.
+
+### 3. Does `sift-mcp` eventually merge into `sift-api` as one service with two surfaces?
+
+The MCP is a separate Python service today that shares Postgres but nothing else. Merging would let `compare_outlets`-style hybrid workflows live next to the rest of the LangGraph pipeline.
+
+Won't resolve until ~3 months of usage data + an actual feature that needs cross-surface code-sharing.
+
+### 4. DMCA fair-use posture for AI summarization
+
+Per Railway's 2026 fair-use clause (lists "Hosting/Distribution of DMCA protected content" as prohibited) + the live NYT / Perplexity / AP litigation landscape: audit needed to confirm `services/` doesn't write original article body HTML or images to disk on Railway, and `/methodology` (sibling `sift` repo) needs a transformative-use posture paragraph before any user-submitted-URL features (e.g. iOS share extension) ship. Tracked as Next-3 item #2 below.
 
 ## Next 3
 
@@ -37,4 +61,4 @@ Per Railway's 2026 fair-use clause (lists "Hosting/Distribution of DMCA protecte
 
 ---
 
-*See also: [`CLAUDE.md`](./CLAUDE.md) (orientation), [`README.md`](./README.md), [`init.sql`](./init.sql). Sibling repos: `sift` (frontend, owns user-facing reads + civic surface), `sift-mcp` (MCP server, separate cadence).*
+*See also: [`CLAUDE.md`](./CLAUDE.md) (orientation), [`BACKLOG.md`](./BACKLOG.md) (deferred items), [`README.md`](./README.md), [`init.sql`](./init.sql). Sibling repos: `sift` (frontend, owns user-facing reads + civic surface), `sift-mcp` (MCP server, separate cadence).*


### PR DESCRIPTION
## Summary

State management completion for `sift-api`:

| File | Change |
|---|---|
| `.claude/settings.json` | Added SessionStart hook (auto-loads STATUS.md into model context at session start) |
| `STATUS.md` | Appended 3 strategic questions captured from the (now closed) PR #57 — scale trigger, entity-linker durability, sift-mcp ↔ sift-api merger. DMCA question reframed as #4. |
| `BACKLOG.md` | New stub — stretch / bugs-to-revisit / considered-and-rejected sections. First entry: deferred canonical `/v1/*` mobile API decision. |

## Supersedes PR #57

Another Claude session opened [#57](https://github.com/kristenmartino/sift-api/pull/57) ("Set up project state management") at 6:44am — 30 min before this PR. It tried to scaffold STATUS.md + CLAUDE.md from scratch, but PR #55 had already merged those an hour earlier. So #57 conflicted with current main.

Closed #57 as superseded; this PR captures the unique value it had (3 strategic questions, BACKLOG.md stub).

## What's left unchanged from #57

- `CLAUDE.md` — already augmented in #55. #57's version proposed slightly different framing but the in-place content covers the same ground (pre-session ritual + end-of-PR doc-impact check).
- The Active focus + Recent decisions sections of STATUS.md — kept as-is from #55. #57's version had more PR-specific detail but the existing version captures the same scope at a higher level.

## SessionStart hook — how it works

```bash
test -f STATUS.md && jq -Rs '{hookSpecificOutput:{hookEventName:"SessionStart",additionalContext:.}}' < STATUS.md || echo '{}'
```

5-second timeout. Falls through to no-op if STATUS.md is missing. Mirrors the same hook in sift (sift#103).

## Test plan

- [ ] PR merges cleanly
- [ ] `.claude/settings.json` validates as JSON (`jq -e 'has("hooks")'`)
- [ ] STATUS.md renders with the 4-question section
- [ ] BACKLOG.md renders correctly
- [ ] Next session opens this repo and STATUS.md content appears in initial context

🤖 Generated with [Claude Code](https://claude.com/claude-code)