### PR TITLE
docs: protocol decision + merge + Ask Sift + Refined Compare plans

### DIFF
--- a/docs/MERGE_MCP_INTO_API.md
+++ b/docs/MERGE_MCP_INTO_API.md
@@ -1,0 +1,176 @@
+# sift-api + sift-mcp — Merged Service Architecture
+
+Purpose: spec what it looks like to consolidate sift-mcp into sift-api
+as a single Python service exposing two transports (HTTP REST + MCP).
+Resolves STATUS.md "open strategic question #2" in favor of merging.
+
+## Why now
+
+- v0.5 (sift-mcp #2 + #4) would otherwise duplicate cost-cap
+  primitives, auth middleware, and observability across two services.
+- The mobile-app trigger forces a decision on hosting; merging
+  collapses the deploy/DNS/observability work for #4 into a no-op
+  (it's just a sift-api deploy).
+- Three months of usage data threshold from STATUS.md is moot if
+  v0.5 itself doubles the duplication tax.
+
+## Current state
+
+```
+sift-api/                          sift-mcp/
+  app/                               src/sift_mcp/
+    pipeline/  (RSS, summarize)        server.py  (5 MCP tools)
+    routes/    (REST endpoints)        db.py      (asyncpg pool)
+    db.py      (asyncpg pool)        Dockerfile
+  Dockerfile                         (Railway: separate service, not
+  (Railway: api.siftnews...)          yet deployed)
+```
+
+Both pools hit the same Neon Postgres. Both consume the same env vars
+(DATABASE_URL, VOYAGE_API_KEY, ANTHROPIC_API_KEY). compare_outlets
+duplicates ranking/embedding logic that arguably should live next to
+the pipeline that produced the index.
+
+## Target state
+
+Single repo (sift-api), single service, two transports backed by
+shared handlers:
+
+```
+sift-api/
+  app/
+    main.py                  # FastAPI app; mounts both transports
+    transports/
+      http.py                # REST routes (existing)
+      mcp.py                 # MCP tool registry (HTTP/SSE + stdio)
+    handlers/
+      articles.py            # search_articles, get_article
+      dossiers.py            # get_dossier, search_dossiers
+      compare.py             # compare_outlets (index + web)
+    pipeline/                # RSS, summarize, dedupe, embed (unchanged)
+    db.py                    # one asyncpg pool, shared
+    auth.py                  # Bearer middleware (mounted on /mcp)
+    caps.py                  # cost cap primitives (sift-mcp #2)
+    entrypoints/
+      web.py                 # uvicorn launch — production
+      mcp_stdio.py           # stdio launch — local Claude Desktop/Code
+  Dockerfile
+  railway.toml
+```
+
+Tool handlers are transport-agnostic:
+
+```python
+# app/handlers/articles.py
+async def search_articles(query: str, category: str | None, limit: int):
+    ...
+
+# app/transports/http.py
+@router.get("/api/search")
+async def http_search(q: str, category: str | None = None, limit: int = 10):
+    return await handlers.search_articles(q, category, limit)
+
+# app/transports/mcp.py
+@mcp.tool()
+async def search_articles(query: str, category: str | None = None, limit: int = 10):
+    return await handlers.search_articles(query, category, limit)
+```
+
+## Surfaces after merge
+
+| Surface | URL / invocation | Auth | Notes |
+|---|---|---|---|
+| REST (sift frontend, mobile app) | api.siftnews.kristenmartino.ai/api/* | session / token | existing |
+| MCP HTTP/SSE | api.siftnews.kristenmartino.ai/mcp | Bearer | sift-mcp #4's hosting becomes a route mount |
+| MCP stdio (local) | uv run python -m sift_api.entrypoints.mcp_stdio | none | for Claude Desktop / Code; replaces sift-mcp invocation |
+
+`mcp.siftnews.kristenmartino.ai` subdomain becomes unnecessary.
+
+## Migration plan
+
+1. **Phase 0 (do BEFORE #2 and #4):** Merge sift-mcp source into
+   sift-api on a feature branch.
+   - Use `git subtree add` (or merge with --allow-unrelated-histories)
+     to preserve sift-mcp's git history inside sift-api.
+   - Wire mcp.py transport mount into FastAPI.
+   - Add entrypoints/mcp_stdio.py.
+   - Confirm all 5 tools work via both transports (smoke-test against
+     MCP Inspector for stdio; curl /mcp for HTTP/SSE).
+   - Land in one PR.
+
+2. **Phase 1 (sift-mcp #2):** Build cost-cap primitives in
+   app/caps.py. Both transports automatically benefit.
+
+3. **Phase 2 (sift-mcp #4):** Add Bearer auth middleware to the /mcp
+   mount only. Tokens table migration in sift-api/init.sql. No new
+   Railway service, no new subdomain, no new env-var set, no DNS work.
+
+4. **Cleanup:** Archive sift-mcp repo with a README pointing at
+   sift-api. Don't delete — preserves issue history (#2–#8 still
+   discoverable). Existing Claude Desktop / Code configs need a
+   one-line update to the new entrypoint; document in sift-api README.
+
+## v0.5 effort delta
+
+| Work | Two-service estimate | Merged estimate |
+|---|---|---|
+| #2 cost caps | 1 week | 4–5 days (no cross-repo coordination) |
+| #4 HTTP/SSE + hosting | 1 week | 2–3 days (route mount, not new service) |
+| Phase 0 merge | n/a | 1–2 days |
+| **Total** | **~2 weeks** | **~7–10 days** |
+
+Net: ~3–5 days saved, plus the ongoing duplication-tax savings on
+every future change that touches data access.
+
+## Trade-offs
+
+**Pro**
+- One asyncpg pool, one logging surface, one deploy target.
+- Tool handlers and pipeline business logic share modules — change
+  ranking once, MCP search reflects it.
+- Cost caps and auth live in one place, applied uniformly.
+- Smaller blast radius for ops mistakes (one service to monitor).
+- Honest answer to STATUS.md question #2 instead of letting it drift.
+
+**Con**
+- MCP and HTTP can't scale independently. Theoretical at current
+  traffic; reconsider if MCP traffic ever spikes beyond what shared
+  capacity can absorb.
+- sift-api becomes a bigger codebase. Mitigated by the handlers/
+  transports/ split, which keeps each transport thin.
+- Git history fragmentation if subtree merge isn't done carefully.
+- Loses the "sift-mcp as a standalone open-source MCP demo" framing.
+  Re-export as a sample if that framing matters for portfolio /
+  hiring.
+
+**Reversible?** Mostly yes. The handler module split means re-extracting
+sift-mcp later is a `git filter-branch` away. The harder-to-reverse
+piece is any custom MCP framework integration done at the FastAPI
+mount point — keep that thin.
+
+## Open questions to resolve before Phase 0
+
+1. **MCP SDK + FastAPI compatibility.** Confirm the mcp Python SDK
+   can mount as an ASGI sub-app inside FastAPI for the HTTP/SSE
+   transport. Expected yes; verify in a 30-min spike.
+2. **Pipeline + tool handler separation.** Confirm no circular
+   imports between pipeline/ (writes data) and handlers/ (reads
+   data). They share db.py but should not import each other.
+3. **Stdio entrypoint ergonomics.** Confirm `uv run python -m
+   sift_api.entrypoints.mcp_stdio` boots cleanly without spinning up
+   FastAPI/uvicorn for local Claude Desktop / Code use.
+4. **CI matrix.** Existing sift-api CI runs pipeline + REST tests.
+   Add MCP tool tests; cap CI runtime at current budget.
+
+## Decision needed
+
+If the answer is "merge," reorder the v0.5 roadmap:
+
+1. Phase 0 (1–2 days): merge sift-mcp into sift-api.
+2. sift-api #54 (1 day): DMCA audit + methodology page.
+3. sift-mcp #2 → sift-api caps (4–5 days): cost caps as merged code.
+4. Mobile-app discovery checklist resolves protocol question.
+5. If #4 still needed: ship as /mcp route + Bearer auth (2–3 days).
+
+If the answer is "don't merge," go with the original two-week
+two-PR plan and accept the duplication tax.

--- a/docs/MOBILE_PROTOCOL_DECISION.md
+++ b/docs/MOBILE_PROTOCOL_DECISION.md
@@ -1,0 +1,108 @@
+# Mobile App → Protocol Decision Checklist
+
+Purpose: resolve whether the mobile app needs to call sift-mcp (MCP
+protocol) or sift-api (REST) before committing to sift-mcp #4
+(HTTP/SSE + hosting). Wrong answer here costs 1–2 weeks of misplaced
+infrastructure work.
+
+## Inputs to read first
+
+- docs/IOS_APP_PLAN.md
+- docs/IOS_APP_ASSESSMENT.md
+- docs/IOS_VS_ANDROID.md
+- Any mobile-app PRD or wireframes (where do they live?)
+
+If those don't exist or don't specify AI architecture: stop and write
+that decision down before any backend work begins. The mobile app's
+AI architecture is a precondition for v0.5 backend work, not an
+output of it.
+
+## Decision tree
+
+For EACH AI/data feature the mobile app will have, answer:
+
+### Q1 — Where does the LLM run for this feature?
+
+- [ ] **No LLM at tap time** — feature just displays AI content that
+      was generated server-side ahead of time (e.g., article primers,
+      pre-computed dossiers, daily briefings).
+      → **REST**. No MCP needed. Skip the rest.
+
+- [ ] **On-device LLM** (Apple Intelligence, on-device Claude SDK, etc.).
+      → Go to Q2.
+
+- [ ] **Server-side LLM** — your backend calls Claude on the user's
+      behalf and returns the result.
+      → Go to Q3.
+
+- [ ] **External AI** (Siri, ChatGPT app, third-party agent invokes
+      Sift via App Intents / Siri Shortcuts).
+      → **App Intents / Siri Intents** on iOS. Not MCP, not REST.
+
+### Q2 — On-device LLM: does it need tool use?
+
+- [ ] **Yes, it makes tool calls** (e.g., "Get me the dossier for
+      Senator X" mid-conversation).
+      → MCP is plausible, but the native Anthropic SDK with a custom
+      tool-handler that hits your REST API is usually simpler than
+      embedding an MCP client on mobile. Pick MCP only if the
+      on-device runtime expects MCP natively.
+
+- [ ] **No, it just generates text from context the app provides.**
+      → **REST**. App fetches data, hands the text to the LLM. MCP
+      adds nothing.
+
+### Q3 — Server-side LLM: hosted MCP or in-process?
+
+- [ ] **Server runs Claude with tool use against our data.**
+      → **Internal MCP** (in-process or stdio invocation from within
+      sift-api). NOT a public hosted MCP. sift-mcp #4 is not required.
+
+- [ ] **Users authenticate with their own Anthropic key and call
+      Claude directly from the app, which then calls our MCP.**
+      → Unusual; almost always **REST** instead. The user-pays model
+      is hard to scale and creates support overhead.
+
+## Per-feature worksheet
+
+| Feature | What user taps | Required data | Where AI runs | Protocol |
+|---|---|---|---|---|
+| Daily briefing | "Brief me" tile | Today's top 10 + dossier links | Server-side at tap | REST → server uses internal MCP |
+| Story compare | "Compare" on article | claims per outlet | Server-side at tap | REST → server uses internal MCP |
+| Topic search | Search bar | Vector-ranked articles | None (pre-indexed) | REST |
+| Ask-Sift chat | "Ask" overlay | Open-ended | On-device LLM with tools | MCP (only if SDK demands) or REST |
+| Siri "what's new in energy" | Siri activation | Top 3 stories | None | App Intents |
+
+Fill the table in for the actual planned features. If column 5 has
+zero "MCP" entries, the right move is:
+
+- Drop sift-mcp #4 entirely from the v0.5 roadmap.
+- Ship sift-mcp #2 (cost caps) standalone, keep sift-mcp stdio-only.
+- Build the mobile REST surface on sift-api instead.
+
+If column 5 has any "MCP (internal)" entries, the right move is:
+
+- Drop sift-mcp #4 (no public hosting needed).
+- Merge sift-mcp into sift-api so internal calls don't cross process
+  boundaries (see docs/MERGE_MCP_INTO_API.md).
+
+If column 5 has any "MCP (public)" entries (rare), proceed with #4
+but only for those specific features and only after confirming the
+mobile platform actually wants the MCP transport.
+
+## Stop conditions
+
+Do NOT proceed to sift-mcp #4 implementation if any of these are true:
+
+1. The mobile app's AI architecture is not yet documented.
+2. The per-feature worksheet above has zero "MCP (public)" entries.
+3. sift-api #54 (DMCA audit + methodology) has not landed.
+4. No specific mobile feature has named a launch date that requires
+   the hosted MCP to be live first.
+
+## Owner
+
+- Mobile lead answers Q1–Q3 per feature.
+- Backend lead reviews and decides architecture.
+- Decision recorded in docs/IOS_APP_PLAN.md or a new
+  docs/MOBILE_PROTOCOL_DECISION_OUTCOME.md.


### PR DESCRIPTION
## Summary

Four decision docs that gate v1.5 work across `sift-api`, `sift`, and `sift-mcp`. All four surface decisions to make BEFORE the next implementation PR, not commitments to ship.

### `docs/MOBILE_PROTOCOL_DECISION.md`

Per-feature decision tree to resolve whether the mobile app needs MCP or REST. **Decision landed 2026-05-20**: Android v1 is REST-only — including the new agentic surfaces (Ask Sift, Refined Compare). The agent loops run server-side; MCP is internal plumbing if used at all. Updated worksheet shows zero "MCP (public)" entries even with agentic features added.

### `docs/MERGE_MCP_INTO_API.md`

Spec for consolidating `sift-mcp` into `sift-api` as one Python service with two transports (REST + MCP). Tracked for execution in **#62**.

Key finding: duplication is already real (`sift-api` `/analyze/compare` and `sift-mcp` `compare_outlets` are parallel implementations). The merge consolidates them. With Ask Sift + Refined Compare as new internal LLM consumers of the same tool surface, **Pattern Y (unified MCP) becomes more attractive** than Pattern X.

### `docs/ASK_SIFT_PLAN.md` (updated)

v0 plan for agentic chat surface. **Status: approved for v1.5** (was v1.6). Ships in BOTH web AND Android v1 — not as a v1.1 add-on. Reasoning: Ask Sift is the differentiator that justifies native mobile over a PWA. Tracked in **#63** (now multi-phase, retiered v1.5).

### `docs/REFINED_COMPARE_PLAN.md` (new)

Sibling specialized agent to Ask Sift. Lens-driven structured comparison: `POST /api/compare` accepts an optional `lens` parameter ("how outlets define X", "explain X's stance on Y", etc.) that routes to an agent loop instead of the current claim-extraction path. Same endpoint, same response envelope. Tracked as a phase of #63.

## Why these together

Discovery during this PR's review surfaced four threads:

1. The mobile app doesn't need MCP → `sift-mcp` #4 is not blocking → merge is safe to land
2. The web app already calls a duplicate `compare` implementation in sift-api → merge isn't hypothetical
3. An in-app agent ("Ask Sift") could be the missing v1 differentiator → benefits from the merge
4. "Refined Compare" with a user-supplied lens is a real product need → another specialized agent sharing the tool surface → strengthens the case for Pattern Y

All four docs are pieces of the same architectural decision.

## Test plan

Docs-only PR; no code paths to test.

- [ ] Confirm Android plan reflects REST-only protocol (cross-check `sift` PR #108)
- [ ] Triage #62 (merge) and #63 (Ask Sift + Refined Compare) into the sequenced roadmap
- [ ] Decide Pattern X vs Y for the internal tool layer (either works; this PR is pattern-agnostic)

## Related

- New tracking issues: **#62** (merge) and **#63** (Ask Sift + Refined Compare, retiered v1.5)
- `sift-mcp` #2 — Cost caps (rolled into #62 Phase 1)
- `sift-mcp` #4 — HTTP/SSE + Railway deploy (likely superseded by #62 Phase 2)
- `sift-api` #54 — DMCA audit (hard prereq for any public MCP, soft prereq for public Ask Sift launch)
- Companion PRs: `sift` #108 (STATUS + ANDROID_APP_v1.md update), `sift-mcp` #13 (STATUS update)