### PR TITLE
docs: normalize refresh cadence and pipeline trigger example

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Handles the background content pipeline (RSS feeds → Claude Haiku summaries �
 ## Architecture
 
 ```
-Railway asyncio scheduler (every 10 min)
+Railway asyncio scheduler (every 30 min)
   → LangGraph pipeline: fetch_rss → deduplicate → summarize (Claude) → embed (Voyage) → store (Postgres)
 
 User compare request (via Vercel proxy)
@@ -48,11 +48,11 @@ uvicorn app.main:app --reload --port 8000
 # Health check
 curl http://localhost:8000/health
 
-# Trigger pipeline (technology category)
+# Trigger the RSS pipeline (refreshes all categories; there is no category-scoped refresh)
 curl -X POST http://localhost:8000/pipeline/refresh \
   -H "Content-Type: application/json" \
   -H "X-Pipeline-Key: dev-key" \
-  -d '{"categories": ["technology"]}'
+  -d '{"force": true}'
 
 # Multi-source comparison
 curl -X POST http://localhost:8000/analyze/compare \

--- a/STATUS.md
+++ b/STATUS.md
@@ -14,10 +14,10 @@ Four live unknowns. None block current work; all shape decisions in the next 1â€
 
 ### 1. When does sift-api need to scale beyond Railway hobby tier?
 
-Pipeline runs every 10 min, ingests ~135 sources, calls Claude for summaries + entity linking + primer generation. Today: comfortably under hobby-tier limits.
+Pipeline runs every 30 min, ingests ~135 sources, calls Claude for summaries + entity linking + primer generation. Today: comfortably under hobby-tier limits.
 
 Watch for:
-- Pipeline run time exceeds 8 min (close to the 10-min cadence)
+- Pipeline run time approaches the 30-min cadence (e.g. exceeds ~25 min)
 - Anthropic monthly bill from pipeline crosses $50/mo (today: ~$15)
 - Neon Postgres connection pool `max=5` starts queuing requests visibly
 - Native app launches and pushes write volume up

--- a/app/main.py
+++ b/app/main.py
@@ -25,7 +25,7 @@ REFRESH_INTERVAL = 30 * 60  # 30 minutes (was 10 min) — stretched to cut spend
 
 
 async def _scheduled_refresh():
-    """Run pipeline refresh every 10 minutes in production."""
+    """Run the pipeline on a fixed interval (REFRESH_INTERVAL, 30 min) in production."""
     await asyncio.sleep(60)  # let the app fully start and serve initial requests
     while True:
         try:

--- a/services/batch_poller.py
+++ b/services/batch_poller.py
@@ -2,7 +2,7 @@
 then routes results to kind-specific handlers that update Postgres.
 
 Runs indefinitely while the app is up. Poll interval is short (60s) relative
-to Railway refresh cadence (600s), so completed batches surface quickly.
+to Railway refresh cadence (1800s), so completed batches surface quickly.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
## What
Normalize the pipeline refresh cadence to **30 min** everywhere it describes current behavior, and fix the README pipeline-trigger example so it no longer implies a category-scoped refresh that doesn't exist. **Docs/comments only — no runtime behavior changes.**

Closes #65
Closes #66

## Why
- The scheduler runs every 30 min (`REFRESH_INTERVAL = 30 * 60` in `app/main.py`, comment: *"was 10 min — stretched to cut spend 66%"*), but several docs/docstrings still said 10 min.
- The README `POST /pipeline/refresh` example sent `{"categories": ["technology"]}`, but `PipelineRequest` only has `force: bool`. Pydantic silently ignored the extra field, so the example *looked* like a per-category refresh while actually running the whole pipeline.

## Files changed (before → after)
| File | Before | After |
|------|--------|-------|
| `app/main.py` (docstring) | `Run pipeline refresh every 10 minutes in production.` | `Run the pipeline on a fixed interval (REFRESH_INTERVAL, 30 min) in production.` |
| `README.md` (architecture) | `Railway asyncio scheduler (every 10 min)` | `… (every 30 min)` |
| `README.md` (verify curl) | `# Trigger pipeline (technology category)` + `-d '{"categories": ["technology"]}'` | `# Trigger the RSS pipeline (refreshes all categories; there is no category-scoped refresh)` + `-d '{"force": true}'` |
| `STATUS.md` | `Pipeline runs every 10 min …` + watch-signal `exceeds 8 min (close to the 10-min cadence)` | `… every 30 min …` + `approaches the 30-min cadence (e.g. exceeds ~25 min)` |
| `services/batch_poller.py` (docstring) | `… refresh cadence (600s) …` | `… refresh cadence (1800s) …` |

## Out of scope (intentionally)
- **#67** (zero-vector embedding fallback) — a real code/data-quality change; gets its own PR with tests.
- **`sift/README.md`** frontend architecture diagram (also says "cron /10min") — separate repo; lands as a companion `sift` PR tracked in #65.

## Notes
- Already-correct references left as-is: `workflows/pipeline_workflow.py:22` (*"scheduler runs every 30 min"*) and `scripts/README.md` (politician-profile **data** cadence — unrelated to the pipeline scheduler).
- ✅ `py_compile` + `ruff check` clean on the two touched Python files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
