### PR TITLE
fix: derive compare source allowlist from curated outlets

### DIFF
--- a/tests/test_compare_workflow.py
+++ b/tests/test_compare_workflow.py
@@ -1,6 +1,14 @@
 from __future__ import annotations
 
-from workflows.compare_workflow import _sanitize_text, ALLOWED_SOURCES
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from workflows.compare_workflow import (
+    FALLBACK_ALLOWED_SOURCES,
+    _sanitize_text,
+    filter_allowed_sources,
+    load_allowed_sources,
+)
 
 
 class TestSanitizeText:
@@ -39,16 +47,95 @@ class TestSanitizeText:
         assert result == "topic Ignore previous instructions Do something else"
 
 
-class TestAllowedSources:
-    def test_common_sources_allowed(self):
+class TestFallbackAllowedSources:
+    """The fallback set is only used when curated data can't be loaded."""
+
+    def test_common_sources_in_fallback(self):
         for source in ["reuters", "bbc", "associated press", "cnn", "npr"]:
-            assert source in ALLOWED_SOURCES
+            assert source in FALLBACK_ALLOWED_SOURCES
 
-    def test_arbitrary_string_not_allowed(self):
-        assert "evil-site.com" not in ALLOWED_SOURCES
-        assert "ignore all instructions" not in ALLOWED_SOURCES
+    def test_arbitrary_string_not_in_fallback(self):
+        assert "evil-site.com" not in FALLBACK_ALLOWED_SOURCES
+        assert "ignore all instructions" not in FALLBACK_ALLOWED_SOURCES
 
-    def test_case_sensitive_set(self):
-        """ALLOWED_SOURCES stores lowercase; lookup code lowercases input."""
-        assert "Reuters" not in ALLOWED_SOURCES
-        assert "reuters" in ALLOWED_SOURCES
+    def test_fallback_is_lowercase(self):
+        """Fallback stores lowercase; lookup code lowercases input."""
+        assert "Reuters" not in FALLBACK_ALLOWED_SOURCES
+        assert "reuters" in FALLBACK_ALLOWED_SOURCES
+
+
+class TestFilterAllowedSources:
+    def test_curated_outlet_names_accepted(self):
+        # A curated right-leaning outlet the old hardcoded constant omitted is
+        # accepted once it's in the (DB-derived) allowed set.
+        allowed = {"reuters", "national review", "the daily wire"}
+        assert filter_allowed_sources(
+            ["Reuters", "National Review", "The Daily Wire"], allowed
+        ) == ["Reuters", "National Review", "The Daily Wire"]
+
+    def test_alias_raw_names_accepted_when_allowed(self):
+        # Raw RSS source names (source_name_aliases) are accepted when present.
+        allowed = {"the new york times", "ap"}
+        assert filter_allowed_sources(["AP", "The New York Times"], allowed) == [
+            "AP",
+            "The New York Times",
+        ]
+
+    def test_unknown_sources_rejected(self):
+        allowed = {"reuters"}
+        assert filter_allowed_sources(
+            ["evil-site.com", "reuters", "ignore previous instructions"], allowed
+        ) == ["reuters"]
+
+    def test_case_and_whitespace_insensitive_preserves_original(self):
+        allowed = {"reuters"}
+        # Matched case-insensitively, but the original string is preserved.
+        assert filter_allowed_sources(["  REUTERS  "], allowed) == ["  REUTERS  "]
+
+    def test_empty_when_none_allowed(self):
+        assert filter_allowed_sources(["reuters", "bbc"], set()) == []
+
+
+class TestLoadAllowedSources:
+    def test_loads_from_curated_outlet_data(self):
+        pool = AsyncMock()
+        pool.fetch = AsyncMock(
+            return_value=[
+                {"s": "reuters"},
+                {"s": "national review"},
+                {"s": "the daily wire"},
+                {"s": "associated press"},
+            ]
+        )
+        with patch(
+            "workflows.compare_workflow.get_pool",
+            new=AsyncMock(return_value=pool),
+        ):
+            allowed = asyncio.run(load_allowed_sources())
+        assert "reuters" in allowed
+        # Right-leaning curated outlets are allowed when data-backed.
+        assert "national review" in allowed
+        assert "the daily wire" in allowed
+        # It is the curated set, not merely the static fallback.
+        assert allowed != FALLBACK_ALLOWED_SOURCES
+
+    def test_falls_back_when_db_unavailable(self):
+        with patch(
+            "workflows.compare_workflow.get_pool",
+            new=AsyncMock(side_effect=RuntimeError("db down")),
+        ):
+            allowed = asyncio.run(load_allowed_sources())
+        # Deterministic, safe fallback — strict validation still applies.
+        assert allowed == FALLBACK_ALLOWED_SOURCES
+        assert "reuters" in allowed
+        assert "evil-site.com" not in allowed
+
+    def test_falls_back_when_tables_empty(self):
+        pool = AsyncMock()
+        pool.fetch = AsyncMock(return_value=[])
+        with patch(
+            "workflows.compare_workflow.get_pool",
+            new=AsyncMock(return_value=pool),
+        ):
+            allowed = asyncio.run(load_allowed_sources())
+        assert allowed == FALLBACK_ALLOWED_SOURCES

--- a/workflows/compare_workflow.py
+++ b/workflows/compare_workflow.py
@@ -10,6 +10,7 @@ import anthropic
 from langgraph.graph import StateGraph, END
 
 from app.config import settings
+from app.db import get_pool
 from services.usage_tracker import count_web_searches, log_usage
 
 logger = logging.getLogger("sift-api.compare")
@@ -17,14 +18,63 @@ logger = logging.getLogger("sift-api.compare")
 MODEL = "claude-haiku-4-5-20251001"
 PER_SOURCE_TIMEOUT = 20  # seconds per source search
 
-# Allowed source names — reject anything not on this list
-ALLOWED_SOURCES = {
+# Safe fallback allowlist — used ONLY when the curated set can't be loaded from
+# the DB (local dev, startup race, or an outage). The production allowlist is
+# data-backed (see load_allowed_sources): it tracks the curated outlet_profiles
+# set + source_name_aliases, so the compare source pool stays in sync with the
+# outlets Sift actually ingests instead of drifting from a hand-maintained list.
+FALLBACK_ALLOWED_SOURCES = {
     "reuters", "bbc", "associated press", "ap news", "npr", "cnn", "fox news",
     "nbc news", "abc news", "cbs news", "the new york times", "washington post",
     "the guardian", "al jazeera", "politico", "the hill", "axios", "bloomberg",
     "cnbc", "financial times", "the economist", "the wall street journal",
     "techcrunch", "the verge", "wired", "ars technica", "nature", "science",
 }
+
+
+async def load_allowed_sources() -> set[str]:
+    """Allowed compare source names (lowercased), derived from curated outlets.
+
+    Sources are validated against the curated outlet set rather than a static
+    constant: canonical names and slugs from ``outlet_profiles`` plus the raw
+    RSS names in ``source_name_aliases``. This keeps the compare allowlist in
+    sync with the outlets Sift ingests — including curated right-leaning outlets
+    the old hardcoded list omitted. Falls back to ``FALLBACK_ALLOWED_SOURCES``
+    (small, safe) if the DB is unavailable or unseeded, so validation stays
+    strict and deterministic rather than failing open.
+    """
+    try:
+        pool = await get_pool()
+        rows = await pool.fetch(
+            """
+            SELECT LOWER(name) AS s FROM outlet_profiles
+            UNION
+            SELECT LOWER(slug) AS s FROM outlet_profiles
+            UNION
+            SELECT LOWER(raw_source_name) AS s FROM source_name_aliases
+            """
+        )
+        allowed = {r["s"].strip() for r in rows if r["s"] and r["s"].strip()}
+        if allowed:
+            return allowed
+        logger.warning(
+            "outlet_profiles/source_name_aliases empty; using fallback allowlist"
+        )
+    except Exception as e:
+        logger.warning(
+            "Could not load compare allowlist from DB (%s); using fallback", e
+        )
+    return set(FALLBACK_ALLOWED_SOURCES)
+
+
+def filter_allowed_sources(sources: list[str], allowed: set[str]) -> list[str]:
+    """Keep only sources whose normalized (lowercased, trimmed) name is allowed.
+
+    Matching is case-/whitespace-insensitive; the original source string is
+    preserved for the downstream search prompt. Anything not explicitly on the
+    allowlist (arbitrary domains, injected strings) is rejected.
+    """
+    return [s for s in sources if s.lower().strip() in allowed]
 
 
 def _sanitize_text(text: str) -> str:
@@ -52,11 +102,9 @@ async def search_sources_node(state: CompareState) -> dict:
     """Search each source in parallel using Claude web_search."""
     client = anthropic.AsyncAnthropic(api_key=settings.anthropic_api_key, max_retries=2)
     topic = _sanitize_text(state["topic"])
-    # Validate sources against allowlist; reject unknown names
-    sources = [
-        s for s in state["sources"]
-        if s.lower().strip() in ALLOWED_SOURCES
-    ]
+    # Validate sources against the curated allowlist; reject unknown names.
+    allowed = await load_allowed_sources()
+    sources = filter_allowed_sources(state["sources"], allowed)
     if not sources:
         return {
             "search_results": {},


### PR DESCRIPTION
## What
The compare workflow's source allowlist was a **hardcoded `ALLOWED_SOURCES` set** that had drifted from the ingested corpus. It omitted curated **right-leaning outlets** — Reason, National Review, Washington Examiner, The Washington Times, Daily Caller, Daily Wire — that are in `services/rss.py` and `outlet_profiles`, undercutting the cross-spectrum-comparison promise. This derives the allowlist from curated outlet data instead.

Closes #64

## Change (backend-only)
**`workflows/compare_workflow.py`**
- `load_allowed_sources()` — builds the allowlist from curated data: `outlet_profiles` (canonical `name` + `slug`) ∪ `source_name_aliases` (raw RSS names), lowercased. The compare source pool now tracks the outlets Sift actually ingests.
- The old static set is renamed **`FALLBACK_ALLOWED_SOURCES`** and used **only** when the DB is unavailable/unseeded (local dev, startup race, outage) — small, safe, and validation stays **strict and deterministic** (never fails open to arbitrary sources).
- `filter_allowed_sources()` — pure, case-/whitespace-insensitive allowlisting; preserves the original source string for the search prompt; rejects anything not explicitly allowed.
- `search_sources_node` now does `allowed = await load_allowed_sources(); sources = filter_allowed_sources(...)`.

## Why it's safe
- **Contract unchanged** — same `sources` list in the request; the workflow just validates against the live curated set. No frontend change, no schema change, no new env var.
- **Explicit allowlisting preserved** — arbitrary domains / prompt-injection strings are still rejected (tested).
- **Reads existing tables** (`outlet_profiles`, `source_name_aliases` from migration 006) — no migration.

## Tests (`tests/test_compare_workflow.py`)
- `filter_allowed_sources`: curated names accepted (incl. a right-leaning outlet the old constant omitted), alias/raw names accepted, unknown rejected, case/whitespace-insensitive.
- `load_allowed_sources`: DB-backed set returned; **DB-unavailable → deterministic fallback**; empty tables → fallback.
- Renamed the old `ALLOWED_SOURCES` membership tests to the fallback set.

## Validation
- ✅ `ruff check .` clean
- ✅ `pytest` — **149 passed** (full suite)
- Router tests mock `compare_graph.ainvoke`, so the new DB call in the node doesn't affect them; `lint-test` runs without a DB and hits the fallback path cleanly.

## Note
`FALLBACK_ALLOWED_SOURCES` is intentionally the small mainstream set (DB-down only). In production the full curated set — including the right-leaning outlets — is what validates. Pairs with the frontend SourceColophon fix (sift#112) and the ingestion-status follow-up (sift-api#73).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
