### PR TITLE
fix: store NULL embeddings when Voyage embedding fails

### DIFF
--- a/services/embedder.py
+++ b/services/embedder.py
@@ -13,16 +13,21 @@ MODEL = "voyage-3-lite"
 BATCH_SIZE = 128  # Voyage AI max batch size
 
 
-async def embed_texts(texts: list[str]) -> list[list[float]]:
+async def embed_texts(texts: list[str]) -> list[list[float] | None]:
     """
     Embed a list of texts using Voyage AI voyage-3-lite.
-    Returns list of 512-dim vectors in the same order as inputs.
+
+    Returns a list aligned 1:1 with ``texts``: a 512-dim vector per text, or
+    ``None`` for any text whose batch failed to embed. Callers persist ``None``
+    as a NULL embedding (never a zero vector), so a failed batch stays out of
+    vector search and can be re-embedded later instead of polluting similarity
+    results with ``[0.0] * 512``.
     """
     if not texts:
         return []
 
     client = voyageai.Client(api_key=settings.voyage_api_key)
-    all_embeddings: list[list[float]] = []
+    all_embeddings: list[list[float] | None] = []
 
     for i in range(0, len(texts), BATCH_SIZE):
         batch = texts[i : i + BATCH_SIZE]
@@ -36,9 +41,24 @@ async def embed_texts(texts: list[str]) -> list[list[float]]:
             )
             all_embeddings.extend(result.embeddings)
         except Exception as e:
-            logger.error("Embedding failed for batch %d: %s", i // BATCH_SIZE, e)
-            # Return zero vectors as fallback for this batch
-            all_embeddings.extend([[0.0] * 512 for _ in batch])
+            logger.error(
+                "Embedding failed for batch %d (%d texts); emitting NULL "
+                "embeddings (skipped, re-embeddable later): %s",
+                i // BATCH_SIZE,
+                len(batch),
+                e,
+            )
+            # Emit None per item (NULL embedding) — never a zero vector. Length
+            # is preserved so the caller's article/vector alignment stays stable.
+            all_embeddings.extend([None] * len(batch))
 
-    logger.info("Embedded %d texts (%d-dim vectors)", len(all_embeddings), 512)
+    embedded = sum(1 for v in all_embeddings if v is not None)
+    skipped = len(all_embeddings) - embedded
+    logger.info(
+        "Embedded %d/%d texts (%d-dim); %d skipped (NULL embedding)",
+        embedded,
+        len(all_embeddings),
+        512,
+        skipped,
+    )
     return all_embeddings

--- a/tests/test_embedder.py
+++ b/tests/test_embedder.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+from services.embedder import BATCH_SIZE, embed_texts
+
+ZERO_VECTOR = [0.0] * 512
+
+
+def _fake_result(n: int):
+    """Stub of a voyageai embed() result with n real 512-dim vectors."""
+    result = MagicMock()
+    result.embeddings = [[0.1] * 512 for _ in range(n)]
+    return result
+
+
+class TestEmbedTexts:
+    def test_empty_input_returns_empty(self):
+        assert asyncio.run(embed_texts([])) == []
+
+    def test_successful_embed_returns_real_vectors(self):
+        texts = ["a", "b", "c"]
+        with patch("services.embedder.voyageai.Client") as Client:
+            Client.return_value.embed.return_value = _fake_result(len(texts))
+            out = asyncio.run(embed_texts(texts))
+        assert len(out) == len(texts)
+        assert all(v is not None and len(v) == 512 for v in out)
+        assert ZERO_VECTOR not in out
+
+    def test_failed_batch_returns_none_not_zero_vectors(self):
+        texts = ["a", "b", "c"]
+        with patch("services.embedder.voyageai.Client") as Client:
+            Client.return_value.embed.side_effect = RuntimeError("voyage down")
+            out = asyncio.run(embed_texts(texts))
+        # Same length, all None — the failure mode is NULL, never a zero vector.
+        assert len(out) == len(texts)
+        assert out == [None, None, None]
+        assert ZERO_VECTOR not in out
+
+    def test_multi_batch_preserves_alignment_on_partial_failure(self):
+        # Two batches: the first (128) succeeds, the second (3) fails. The output
+        # must stay the same length with failed positions as None — proving the
+        # article/vector alignment the pipeline relies on is preserved.
+        texts = [f"t{i}" for i in range(BATCH_SIZE + 3)]
+
+        def embed_side_effect(batch, **kwargs):
+            if "t0" in batch:  # first batch
+                return _fake_result(len(batch))
+            raise RuntimeError("voyage down on second batch")
+
+        with patch("services.embedder.voyageai.Client") as Client:
+            Client.return_value.embed.side_effect = embed_side_effect
+            out = asyncio.run(embed_texts(texts))
+
+        assert len(out) == len(texts)
+        # First batch embedded for real...
+        assert all(v is not None and len(v) == 512 for v in out[:BATCH_SIZE])
+        # ...second (failed) batch is None, never zero vectors.
+        assert out[BATCH_SIZE:] == [None, None, None]
+        assert ZERO_VECTOR not in out

--- a/workflows/pipeline_workflow.py
+++ b/workflows/pipeline_workflow.py
@@ -230,11 +230,20 @@ async def embed_node(state: PipelineState) -> dict:
 
     try:
         vectors = await embed_texts(texts)
+        # Skip articles whose embedding batch failed: omit them from the dict so
+        # store_node writes NULL (not a zero vector). They stay browsable but are
+        # excluded from vector search until a future re-embed pass.
         embeddings = {
             article.source_url: vector
             for article, vector in zip(new_articles, vectors)
+            if vector is not None
         }
-        logger.info("embed: generated %d embeddings", len(embeddings))
+        skipped = len(new_articles) - len(embeddings)
+        logger.info(
+            "embed: generated %d embeddings (%d skipped → NULL)",
+            len(embeddings),
+            skipped,
+        )
         return {"embeddings": embeddings}
     except Exception as e:
         logger.error("embed failed: %s", e)


### PR DESCRIPTION
## What
On a Voyage embedding-batch failure, `embed_texts` returned `[0.0] * 512` for the **entire batch** (up to 128 articles). Those zero vectors were stored as real-looking embeddings and polluted vector/topic search. This stores **NULL** instead.

Closes #67

## Change (no schema change)
- **`services/embedder.py`** — on batch failure, emit `None` per item (→ NULL embedding) instead of a zero vector. Return type is now `list[list[float] | None]`; **output length is preserved** so the caller's article↔vector alignment stays stable.
- **`workflows/pipeline_workflow.py`** — `embed_node` omits `None` vectors from the `embeddings` dict, so `store_node` writes `NULL` via its existing `$9::vector` `None → NULL` path (empirically verified against pgvector). `PipelineState["embeddings"]` stays `dict[str, list[float]]`.
- **`store_node`** — unchanged (already maps a missing embedding → `NULL`).
- **`tests/test_embedder.py` (new)** — success returns real vectors; a failed batch returns a same-length list of `None` and **never `[0.0] * 512`**; a multi-batch partial failure keeps the first batch's real vectors and the failed batch's `None`, proving alignment is preserved.

## Scope (deliberately small)
No schema change · no article-status column · no repair job · no pipeline redesign. Articles with valid summary/category are still inserted; only `embedding` is `NULL`.

## Conscious tradeoff
Articles whose embedding batch fails are still stored with `embedding = NULL`, so they remain **browsable** but are **excluded from vector search** by the existing `embedding IS NOT NULL` filter (`sift/lib/db.ts`). Because dedup is by `source_url`, the normal ingestion path won't retry them — a **follow-up repair pass** can re-embed rows where `embedding IS NULL`. Filed as a backlog follow-up, not part of this PR.

## Validation
- ✅ `ruff check .` clean
- ✅ `pytest tests/test_embedder.py -v` — 4 passed
- ✅ `pytest` — **153 passed** (full suite)
- Empirically confirmed (pgvector): `None → $::vector` stores `NULL`; the `embedding IS NOT NULL` filter excludes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
