### PR TITLE
fix: align backend compare timeout with frontend proxy budget

### DIFF
--- a/app/routers/compare.py
+++ b/app/routers/compare.py
@@ -17,7 +17,9 @@ logger = logging.getLogger("sift-api.compare-router")
 
 router = APIRouter(prefix="/analyze", tags=["compare"])
 
-COMPARE_TIMEOUT = 90  # seconds — max time for entire comparison workflow
+# Overall compare-workflow ceiling. Kept within the frontend proxy budget
+# (sift#122): backend 50s < proxy abort 55s < Vercel maxDuration 60s < client 65s.
+COMPARE_TIMEOUT = 50  # seconds
 
 compare_graph = build_compare_graph()
 
@@ -29,7 +31,7 @@ compare_graph = build_compare_graph()
     description=(
         "Searches multiple news sources for coverage of a topic, extracts key claims, "
         "and compares how sources agree or disagree. Supports up to 5 sources. "
-        "Rate limited to 10 requests per minute. May take up to 90 seconds."
+        "Rate limited to 10 requests per minute. May take up to 50 seconds."
     ),
 )
 @limiter.limit("10/minute")


### PR DESCRIPTION
## What
Lowers the backend compare timeout so it fits within the frontend proxy budget set in sift#122 — closing the loop on the compare-contract alignment.

Closes #77

## The timeout chain (now coherent)
sift#122 (sift#114) fixed the frontend half. The backend's `COMPARE_TIMEOUT` was still 90s — exceeding the proxy's reach, so the backend could keep working ~35s after the proxy abandoned the request (wasted compute on a rate-limited path the client never sees).

| Layer | Budget |
|---|---|
| **backend** `COMPARE_TIMEOUT` | **50s** ← this PR (was 90s) |
| frontend proxy upstream abort | 55s |
| Vercel `maxDuration` | 60s |
| client hook timeout | 65s |

Innermost (backend) now times out **first** and returns its clean `504` ("Comparison timed out…"), which propagates cleanly out to the client.

## Change (backend-only)
- `app/routers/compare.py`: `COMPARE_TIMEOUT` 90 → 50; route description "May take up to 90 seconds" → "50 seconds". Error messaging unchanged (still the friendly 504).

## Out of scope
No frontend, no allowlist, no Refined Compare / Ask Sift / topic-ownership / Sentry / cost-ceiling. A typical compare runs ~20–30s (per-source search is capped at 20s in parallel), so 50s stays a generous ceiling.

## Validation
- ✅ `ruff check .` clean
- ✅ `pytest` — 153 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
