### PR TITLE
obs: add Sentry error monitoring to sift-api

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,8 @@ PIPELINE_API_KEY=change-me-in-production
 PORT=8000
 ENVIRONMENT=development
 LOG_LEVEL=info
+
+# Error monitoring (Sentry) — OPTIONAL. Inert unless SENTRY_DSN is set.
+# No PII is sent (send_default_pii=False). Tracing sample rate is conservative.
+SENTRY_DSN=
+SENTRY_TRACES_SAMPLE_RATE=0.1

--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ CI wires the same script into the **`feed-perf`** job (`.github/workflows/ci.yml
 | `ENVIRONMENT` | No | `development` or `production` (enables background scheduler) |
 | `PORT` | No | Server port (default: 8000, Railway injects 8080) |
 | `LOG_LEVEL` | No | `debug`, `info`, `warning`, `error` |
+| `SENTRY_DSN` | No | Sentry DSN for error monitoring. Inert unless set; no PII sent |
+| `SENTRY_TRACES_SAMPLE_RATE` | No | Sentry tracing sample rate (default: `0.1`) |
 
 ## Tests
 

--- a/app/config.py
+++ b/app/config.py
@@ -12,6 +12,11 @@ class Settings(BaseSettings):
     environment: str = "development"
     log_level: str = "info"
 
+    # Error monitoring (Sentry) — inert unless sentry_dsn (SENTRY_DSN) is set.
+    # Reuses `environment` as the Sentry environment tag.
+    sentry_dsn: str = ""
+    sentry_traces_sample_rate: float = 0.1
+
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -15,6 +15,7 @@ from app.config import settings
 from app.db import init_pool, get_pool, close_pool
 from app.dependencies import limiter
 from app.models import HealthResponse
+from app.observability import init_sentry
 from app.routers import pipeline, compare
 
 logger = logging.getLogger("sift-api")
@@ -88,6 +89,11 @@ async def lifespan(app: FastAPI):
         poller_task.cancel()
     await close_pool()
     logger.info("sift-api shut down")
+
+
+# Initialize error monitoring before the app is created so Sentry's ASGI
+# integration wraps request handling. No-op unless SENTRY_DSN is configured.
+init_sentry()
 
 
 app = FastAPI(

--- a/app/observability.py
+++ b/app/observability.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import logging
+
+import sentry_sdk
+
+from app.config import settings
+
+logger = logging.getLogger("sift-api")
+
+
+def init_sentry() -> bool:
+    """Initialize Sentry error monitoring.
+
+    No-op unless ``SENTRY_DSN`` is configured, so local dev, tests, and any
+    unconfigured deploy run untouched. The FastAPI/Starlette integration is
+    auto-enabled by sentry-sdk when FastAPI is installed; its default
+    failed-request reporting captures unhandled 5xx responses and leaves
+    routine 4xx client errors alone. No PII is sent (``send_default_pii`` is
+    ``False``).
+
+    Returns ``True`` if Sentry was initialized, ``False`` if skipped.
+    """
+    if not settings.sentry_dsn:
+        return False
+
+    sentry_sdk.init(
+        dsn=settings.sentry_dsn,
+        environment=settings.environment,
+        traces_sample_rate=settings.sentry_traces_sample_rate,
+        send_default_pii=False,
+    )
+    logger.info("Sentry error monitoring initialized (env=%s)", settings.environment)
+    return True

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ httpx==0.28.1
 eval-type-backport==0.2.2
 slowapi==0.1.9
 pyyaml==6.0.3
+sentry-sdk==2.61.0
 pytest==8.3.5
 pytest-asyncio==0.24.0
 ruff==0.8.6

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from app import observability
+
+
+class TestInitSentry:
+    def test_noop_without_dsn(self):
+        """Without a DSN, init_sentry returns False and never calls sentry_sdk.init."""
+        with patch.object(observability.settings, "sentry_dsn", ""):
+            with patch.object(observability.sentry_sdk, "init") as mock_init:
+                result = observability.init_sentry()
+        assert result is False
+        mock_init.assert_not_called()
+
+    def test_initializes_with_dsn(self):
+        """With a DSN set, sentry_sdk.init is called once with PII disabled and
+        our environment + traces rate passed through."""
+        dsn = "https://examplePublicKey@o0.ingest.sentry.io/0"
+        with patch.object(observability.settings, "sentry_dsn", dsn):
+            with patch.object(observability.settings, "environment", "production"):
+                with patch.object(
+                    observability.settings, "sentry_traces_sample_rate", 0.25
+                ):
+                    with patch.object(observability.sentry_sdk, "init") as mock_init:
+                        result = observability.init_sentry()
+        assert result is True
+        mock_init.assert_called_once()
+        kwargs = mock_init.call_args.kwargs
+        assert kwargs["send_default_pii"] is False
+        assert kwargs["dsn"] == dsn
+        assert kwargs["environment"] == "production"
+        assert kwargs["traces_sample_rate"] == 0.25


### PR DESCRIPTION
## What
Adds `sentry-sdk` error monitoring to the FastAPI backend. **Inert unless `SENTRY_DSN` is configured** — local dev, tests, and any unconfigured deploy run untouched.

Closes #69

## How
- **`app/observability.py`** — `init_sentry()`: no-op when `SENTRY_DSN` is empty; otherwise `sentry_sdk.init(dsn, environment=settings.environment, traces_sample_rate=settings.sentry_traces_sample_rate, send_default_pii=False)`. The FastAPI/Starlette integration auto-enables (FastAPI is in deps); its default failed-request reporting captures **unhandled 5xx** and leaves routine 4xx alone.
- **`app/config.py`** — `sentry_dsn` + `sentry_traces_sample_rate` settings; reuses the existing `environment` as the Sentry environment tag.
- **`app/main.py`** — calls `init_sentry()` before the app is created, so the ASGI integration wraps request handling. A missing DSN never breaks startup or tests.
- **`requirements.txt`** — `sentry-sdk==2.61.0`.
- **`.env.example` / `README.md`** — document `SENTRY_DSN` + `SENTRY_TRACES_SAMPLE_RATE`.
- **`tests/test_observability.py`** — `init_sentry` no-ops without a DSN; calls `sentry_sdk.init` with `send_default_pii=False` and passes environment + traces rate through.

## Notes
- Sentry initializes only when `SENTRY_DSN` is configured.
- PII is disabled via `send_default_pii=False`.
- Profiling, logs, cron monitoring, and custom AI-cost telemetry are intentionally **not** enabled.
- Cost ceiling remains separate under sift-api#70.

## Scope
Backend-only — no frontend changes; does not touch topic-search migration, compare, embeddings, or cost-ceiling work.

## Validation
- ✅ `ruff check .` — all checks passed
- ✅ `pytest tests/ -v` — **155 passed** (incl. 2 new observability tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
