### PR TITLE
feat: add backend AI cost ceiling guard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,9 @@ LOG_LEVEL=info
 # No PII is sent (send_default_pii=False). Tracing sample rate is conservative.
 SENTRY_DSN=
 SENTRY_TRACES_SAMPLE_RATE=0.1
+
+# Daily AI cost ceiling (sift-api#70) — OPTIONAL. Inert unless enabled.
+# Tracks live-path Claude + Voyage spend; hard-stops paid calls past the limit.
+AI_COST_GUARD_ENABLED=false
+DAILY_AI_COST_LIMIT_USD=10.0
+AI_COST_ALERT_THRESHOLD_RATIO=0.8

--- a/README.md
+++ b/README.md
@@ -150,6 +150,9 @@ CI wires the same script into the **`feed-perf`** job (`.github/workflows/ci.yml
 | `LOG_LEVEL` | No | `debug`, `info`, `warning`, `error` |
 | `SENTRY_DSN` | No | Sentry DSN for error monitoring. Inert unless set; no PII sent |
 | `SENTRY_TRACES_SAMPLE_RATE` | No | Sentry tracing sample rate (default: `0.1`) |
+| `AI_COST_GUARD_ENABLED` | No | Enable the daily AI cost ceiling (default: `false`) |
+| `DAILY_AI_COST_LIMIT_USD` | No | Daily Claude + Voyage spend ceiling, USD (default: `10.0`) |
+| `AI_COST_ALERT_THRESHOLD_RATIO` | No | Budget fraction that triggers an alert (default: `0.8`) |
 
 ## Tests
 

--- a/app/config.py
+++ b/app/config.py
@@ -17,6 +17,13 @@ class Settings(BaseSettings):
     sentry_dsn: str = ""
     sentry_traces_sample_rate: float = 0.1
 
+    # Daily AI cost ceiling (sift-api#70) — inert unless ai_cost_guard_enabled.
+    # Tracks live-path Claude + Voyage spend and hard-stops paid calls for the
+    # rest of the UTC day once daily_ai_cost_limit_usd is reached.
+    ai_cost_guard_enabled: bool = False
+    daily_ai_cost_limit_usd: float = 10.0
+    ai_cost_alert_threshold_ratio: float = 0.8
+
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
 
 

--- a/app/db.py
+++ b/app/db.py
@@ -304,6 +304,25 @@ async def _apply_migrations(pool: asyncpg.Pool) -> None:
             "ON primer_expand_events(article_id) WHERE article_id IS NOT NULL"
         )
 
+        # Daily AI cost ledger (migrations/011_ai_usage_daily.sql).
+        # One row per (UTC date, provider, model, operation). cost_guard sums
+        # the day's estimated_cost_usd to enforce the daily ceiling (sift-api#70)
+        # and alert at 80%. Covers the live paid paths (compare web-search +
+        # Voyage embeddings); frontend topic-search stays a D35 exception
+        # (sift-api#79) until that fallback moves into sift-api.
+        await conn.execute("""
+            CREATE TABLE IF NOT EXISTS ai_usage_daily (
+                usage_date          DATE NOT NULL,
+                provider            TEXT NOT NULL,
+                model               TEXT NOT NULL,
+                operation           TEXT NOT NULL,
+                estimated_cost_usd  DOUBLE PRECISION NOT NULL DEFAULT 0,
+                call_count          INTEGER NOT NULL DEFAULT 0,
+                updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                PRIMARY KEY (usage_date, provider, model, operation)
+            )
+        """)
+
 
 async def get_pool() -> asyncpg.Pool:
     if _pool is None:

--- a/app/routers/compare.py
+++ b/app/routers/compare.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter, Header, HTTPException, Request
 from app.config import settings
 from app.dependencies import limiter
 from app.models import CompareRequest, CompareResponse
+from services.cost_guard import check_budget
 from workflows.compare_workflow import build_compare_graph, CompareState
 
 logger = logging.getLogger("sift-api.compare-router")
@@ -48,6 +49,28 @@ async def compare_sources(
 
     if len(body.sources) > 5:
         raise HTTPException(status_code=400, detail="Maximum 5 sources allowed")
+
+    # Daily AI cost ceiling (sift-api#70): block the live Claude web-search path
+    # when today's spend is over budget. Frontend topic-search is NOT covered
+    # yet — it stays a temporary D35 exception until sift-api#79 moves that
+    # fallback into sift-api.
+    budget = await check_budget()
+    if not budget.allowed:
+        logger.warning(
+            "Compare blocked by daily AI cost ceiling (spent=$%.4f / $%.2f)",
+            budget.spent_usd,
+            budget.limit_usd,
+        )
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "detail": (
+                    "Comparison is temporarily unavailable: today's AI budget "
+                    "has been reached. Please try again tomorrow."
+                ),
+                "code": "AI_BUDGET_EXCEEDED",
+            },
+        )
 
     start = time.time()
 

--- a/app/routers/compare.py
+++ b/app/routers/compare.py
@@ -22,6 +22,12 @@ router = APIRouter(prefix="/analyze", tags=["compare"])
 # (sift#122): backend 50s < proxy abort 55s < Vercel maxDuration 60s < client 65s.
 COMPARE_TIMEOUT = 50  # seconds
 
+# Conservative per-source cost estimate for the daily-budget pre-check
+# (sift-api#70): ~one web search per source (~$0.01) plus Claude tokens for
+# search + extraction. Deliberately on the high side so a compare is blocked
+# *before* it would cross the ceiling, not after.
+COMPARE_COST_ESTIMATE_PER_SOURCE_USD = 0.04
+
 compare_graph = build_compare_graph()
 
 
@@ -51,10 +57,12 @@ async def compare_sources(
         raise HTTPException(status_code=400, detail="Maximum 5 sources allowed")
 
     # Daily AI cost ceiling (sift-api#70): block the live Claude web-search path
-    # when today's spend is over budget. Frontend topic-search is NOT covered
-    # yet — it stays a temporary D35 exception until sift-api#79 moves that
-    # fallback into sift-api.
-    budget = await check_budget()
+    # when today's spend plus this request's estimated cost would exceed budget.
+    # Frontend topic-search is NOT covered yet — it stays a temporary D35
+    # exception until sift-api#79 moves that fallback into sift-api.
+    budget = await check_budget(
+        COMPARE_COST_ESTIMATE_PER_SOURCE_USD * len(body.sources)
+    )
     if not budget.allowed:
         logger.warning(
             "Compare blocked by daily AI cost ceiling (spent=$%.4f / $%.2f)",

--- a/app/routers/compare.py
+++ b/app/routers/compare.py
@@ -65,20 +65,26 @@ async def compare_sources(
     )
     if not budget.allowed:
         logger.warning(
-            "Compare blocked by daily AI cost ceiling (spent=$%.4f / $%.2f)",
+            "Compare blocked by cost guard (reason=%s, spent=$%.4f / $%.2f)",
+            budget.reason,
             budget.spent_usd,
             budget.limit_usd,
         )
-        raise HTTPException(
-            status_code=503,
-            detail={
-                "detail": (
-                    "Comparison is temporarily unavailable: today's AI budget "
-                    "has been reached. Please try again tomorrow."
-                ),
-                "code": "AI_BUDGET_EXCEEDED",
-            },
-        )
+        if budget.reason == "guard_unavailable":
+            # Fail-closed: we couldn't verify today's spend, so we don't make the
+            # paid provider call.
+            detail = (
+                "Comparison is temporarily unavailable: the cost guard could "
+                "not verify the AI budget. Please try again shortly."
+            )
+            code = "COST_GUARD_UNAVAILABLE"
+        else:
+            detail = (
+                "Comparison is temporarily unavailable: today's AI budget has "
+                "been reached. Please try again tomorrow."
+            )
+            code = "AI_BUDGET_EXCEEDED"
+        raise HTTPException(status_code=503, detail={"detail": detail, "code": code})
 
     start = time.time()
 

--- a/init.sql
+++ b/init.sql
@@ -180,3 +180,21 @@ CREATE INDEX IF NOT EXISTS idx_primer_expand_events_created
     ON primer_expand_events(created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_primer_expand_events_article
     ON primer_expand_events(article_id) WHERE article_id IS NOT NULL;
+
+-- Daily AI cost ledger (migrations/011_ai_usage_daily.sql).
+-- One row per (UTC date, provider, model, operation). services/cost_guard.py
+-- sums the day's estimated_cost_usd to enforce a hard daily ceiling on the
+-- live paid paths (compare web-search + Voyage embeddings) and to alert at 80%
+-- of budget (sift-api#70). Frontend topic-search paid calls are NOT covered
+-- here yet — they remain a temporary D35 exception until sift-api#79 moves
+-- that fallback into sift-api.
+CREATE TABLE IF NOT EXISTS ai_usage_daily (
+    usage_date          DATE NOT NULL,
+    provider            TEXT NOT NULL,          -- 'anthropic' | 'voyage'
+    model               TEXT NOT NULL,
+    operation           TEXT NOT NULL,          -- call-site id, e.g. 'compare.search'
+    estimated_cost_usd  DOUBLE PRECISION NOT NULL DEFAULT 0,
+    call_count          INTEGER NOT NULL DEFAULT 0,
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (usage_date, provider, model, operation)
+);

--- a/migrations/011_ai_usage_daily.sql
+++ b/migrations/011_ai_usage_daily.sql
@@ -1,0 +1,23 @@
+-- 011_ai_usage_daily.sql
+-- Daily AI cost ledger backing the cost ceiling (sift-api#70).
+--
+-- One row per (UTC date, provider, model, operation). services/cost_guard.py
+-- sums the day's estimated_cost_usd to (a) hard-stop live paid calls once the
+-- daily limit is reached and (b) alert at 80% of budget. Covers the live paid
+-- paths only — compare web-search (Claude) + Voyage embeddings. Frontend
+-- topic-search paid calls remain a temporary D35 exception until sift-api#79
+-- moves that fallback into sift-api.
+--
+-- Applied at startup (non-CONCURRENTLY, idempotent) by
+-- app/db.py:_apply_migrations. This file is the manual-ops / documentation copy.
+
+CREATE TABLE IF NOT EXISTS ai_usage_daily (
+    usage_date          DATE NOT NULL,
+    provider            TEXT NOT NULL,          -- 'anthropic' | 'voyage'
+    model               TEXT NOT NULL,
+    operation           TEXT NOT NULL,          -- call-site id, e.g. 'compare.search'
+    estimated_cost_usd  DOUBLE PRECISION NOT NULL DEFAULT 0,
+    call_count          INTEGER NOT NULL DEFAULT 0,
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (usage_date, provider, model, operation)
+);

--- a/services/cost_guard.py
+++ b/services/cost_guard.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+
+import sentry_sdk
+
+from app.config import settings
+from app.db import get_pool
+
+logger = logging.getLogger("sift-api.cost_guard")
+
+# In-process de-dup so the "80% of budget" alert fires at most once per UTC day
+# per worker. Cheap and good enough; a restart may re-alert, which is harmless.
+_alerted_dates: set[str] = set()
+
+
+@dataclass(frozen=True)
+class BudgetDecision:
+    """Outcome of a check_budget() call."""
+
+    allowed: bool
+    reason: str
+    spent_usd: float
+    limit_usd: float
+
+
+def _utc_today() -> date:
+    return datetime.now(timezone.utc).date()
+
+
+async def check_budget(estimated_cost_usd: float = 0.0) -> BudgetDecision:
+    """Decide whether a paid AI call may proceed under today's budget.
+
+    Returns ``allowed=True`` when the guard is disabled, when today's spend plus
+    the estimated cost is within ``daily_ai_cost_limit_usd``, or when the ledger
+    can't be read (fail-open: the guard must never become a new outage vector —
+    a transient DB blip should not halt every paid call). Returns
+    ``allowed=False`` only when the projected spend would exceed the limit;
+    callers should then skip the provider call and degrade gracefully.
+    """
+    limit = settings.daily_ai_cost_limit_usd
+    if not settings.ai_cost_guard_enabled:
+        return BudgetDecision(True, "guard_disabled", 0.0, limit)
+
+    try:
+        pool = await get_pool()
+        spent = await pool.fetchval(
+            "SELECT COALESCE(SUM(estimated_cost_usd), 0) "
+            "FROM ai_usage_daily WHERE usage_date = $1",
+            _utc_today(),
+        )
+        spent = float(spent or 0.0)
+    except Exception as e:
+        logger.warning(
+            "cost_guard: ledger read failed, allowing call (fail-open): %s", e
+        )
+        return BudgetDecision(True, "ledger_unavailable", 0.0, limit)
+
+    projected = spent + max(0.0, estimated_cost_usd)
+    if limit > 0 and projected > limit:
+        logger.warning(
+            "cost_guard: daily AI budget reached — blocking paid call "
+            "(spent=$%.4f + est=$%.4f > limit=$%.2f)",
+            spent,
+            estimated_cost_usd,
+            limit,
+        )
+        return BudgetDecision(False, "budget_exceeded", spent, limit)
+
+    _maybe_alert(spent, limit)
+    return BudgetDecision(True, "within_budget", spent, limit)
+
+
+async def record_usage(
+    provider: str,
+    model: str,
+    operation: str,
+    cost_usd: float,
+    call_count: int = 1,
+) -> None:
+    """Add a paid call's estimated cost to today's ledger row.
+
+    No-op when the guard is disabled or there's nothing to record. Never raises:
+    lost telemetry must not break the pipeline or a request.
+    """
+    if not settings.ai_cost_guard_enabled:
+        return
+    if cost_usd <= 0 and call_count <= 0:
+        return
+
+    try:
+        pool = await get_pool()
+        await pool.execute(
+            """
+            INSERT INTO ai_usage_daily
+                (usage_date, provider, model, operation, estimated_cost_usd,
+                 call_count, updated_at)
+            VALUES ($1, $2, $3, $4, $5, $6, NOW())
+            ON CONFLICT (usage_date, provider, model, operation)
+            DO UPDATE SET
+                estimated_cost_usd =
+                    ai_usage_daily.estimated_cost_usd + EXCLUDED.estimated_cost_usd,
+                call_count = ai_usage_daily.call_count + EXCLUDED.call_count,
+                updated_at = NOW()
+            """,
+            _utc_today(),
+            provider,
+            model,
+            operation,
+            float(cost_usd),
+            int(call_count),
+        )
+    except Exception as e:
+        logger.debug(
+            "cost_guard: ledger write failed for %s/%s: %s", provider, operation, e
+        )
+
+
+def _maybe_alert(spent: float, limit: float) -> None:
+    """Emit a single warning per UTC day when spend crosses the alert ratio.
+
+    Always logs; also sends a Sentry message when Sentry is configured
+    (SENTRY_DSN set). Falls back to logs-only when Sentry is inert.
+    """
+    if limit <= 0 or spent / limit < settings.ai_cost_alert_threshold_ratio:
+        return
+
+    today = _utc_today().isoformat()
+    if today in _alerted_dates:
+        return
+    _alerted_dates.add(today)
+
+    msg = (
+        f"AI spend at {spent / limit:.0%} of the daily budget "
+        f"(${spent:.4f} / ${limit:.2f}) on {today}"
+    )
+    logger.warning("cost_guard: %s", msg)
+    if settings.sentry_dsn:
+        try:
+            sentry_sdk.capture_message(msg, level="warning")
+        except Exception as e:
+            logger.debug("cost_guard: sentry alert failed: %s", e)

--- a/services/cost_guard.py
+++ b/services/cost_guard.py
@@ -33,12 +33,14 @@ def _utc_today() -> date:
 async def check_budget(estimated_cost_usd: float = 0.0) -> BudgetDecision:
     """Decide whether a paid AI call may proceed under today's budget.
 
-    Returns ``allowed=True`` when the guard is disabled, when today's spend plus
-    the estimated cost is within ``daily_ai_cost_limit_usd``, or when the ledger
-    can't be read (fail-open: the guard must never become a new outage vector —
-    a transient DB blip should not halt every paid call). Returns
-    ``allowed=False`` only when the projected spend would exceed the limit;
-    callers should then skip the provider call and degrade gracefully.
+    Returns ``allowed=True`` when the guard is disabled, or when today's spend
+    plus the estimated cost is within ``daily_ai_cost_limit_usd``. Returns
+    ``allowed=False`` when the projected spend would exceed the limit — and also
+    when the guard is enabled but the ledger can't be read (fail-closed): if we
+    can't verify spend we must not authorize paid calls, otherwise an enabled
+    ceiling would permit unlimited spend during the exact failure mode where
+    spend can't be measured. Callers should skip the provider call and degrade
+    gracefully whenever ``allowed=False``.
     """
     limit = settings.daily_ai_cost_limit_usd
     if not settings.ai_cost_guard_enabled:
@@ -53,10 +55,14 @@ async def check_budget(estimated_cost_usd: float = 0.0) -> BudgetDecision:
         )
         spent = float(spent or 0.0)
     except Exception as e:
-        logger.warning(
-            "cost_guard: ledger read failed, allowing call (fail-open): %s", e
+        # Fail CLOSED: when the guard is enabled but the ledger can't be read we
+        # can't verify spend, so we must not authorize paid calls. An enabled
+        # ceiling that failed open would permit unlimited spend during the exact
+        # failure mode where spend can't be measured.
+        logger.error(
+            "cost_guard: ledger read failed, blocking call (fail-closed): %s", e
         )
-        return BudgetDecision(True, "ledger_unavailable", 0.0, limit)
+        return BudgetDecision(False, "guard_unavailable", 0.0, limit)
 
     projected = spent + max(0.0, estimated_cost_usd)
     if limit > 0 and projected > limit:

--- a/services/embedder.py
+++ b/services/embedder.py
@@ -28,10 +28,13 @@ async def embed_texts(texts: list[str]) -> list[list[float] | None]:
     if not texts:
         return []
 
-    # Daily AI cost ceiling (sift-api#70): if today's spend is over budget, skip
-    # the paid Voyage call and emit NULL embeddings (re-embeddable later, same
-    # contract as a failed batch) instead of spending past the limit.
-    budget = await check_budget()
+    # Daily AI cost ceiling (sift-api#70): block before the paid Voyage call when
+    # today's spend plus this batch's estimated cost would exceed the limit, and
+    # emit NULL embeddings (re-embeddable later, same contract as a failed batch)
+    # instead of spending past the ceiling. ~4 chars/token is a conservative
+    # pre-estimate so we stop before crossing, not after.
+    estimated_tokens = sum(len(t) for t in texts) // 4
+    budget = await check_budget(voyage_cost(estimated_tokens))
     if not budget.allowed:
         logger.warning(
             "Embedding skipped: daily AI budget reached (spent=$%.4f / $%.2f); "

--- a/services/embedder.py
+++ b/services/embedder.py
@@ -36,11 +36,12 @@ async def embed_texts(texts: list[str]) -> list[list[float] | None]:
     estimated_tokens = sum(len(t) for t in texts) // 4
     budget = await check_budget(voyage_cost(estimated_tokens))
     if not budget.allowed:
+        # Covers both over-budget and guard-unavailable (fail-closed): either
+        # way we do not make the paid Voyage call.
         logger.warning(
-            "Embedding skipped: daily AI budget reached (spent=$%.4f / $%.2f); "
-            "emitting %d NULL embeddings (re-embeddable later).",
-            budget.spent_usd,
-            budget.limit_usd,
+            "Embedding skipped (cost guard: %s); emitting %d NULL embeddings "
+            "(re-embeddable later).",
+            budget.reason,
             len(texts),
         )
         return [None] * len(texts)

--- a/services/embedder.py
+++ b/services/embedder.py
@@ -6,6 +6,8 @@ import logging
 import voyageai
 
 from app.config import settings
+from services.cost_guard import check_budget, record_usage
+from services.usage_tracker import voyage_cost
 
 logger = logging.getLogger("sift-api.embedder")
 
@@ -26,8 +28,23 @@ async def embed_texts(texts: list[str]) -> list[list[float] | None]:
     if not texts:
         return []
 
+    # Daily AI cost ceiling (sift-api#70): if today's spend is over budget, skip
+    # the paid Voyage call and emit NULL embeddings (re-embeddable later, same
+    # contract as a failed batch) instead of spending past the limit.
+    budget = await check_budget()
+    if not budget.allowed:
+        logger.warning(
+            "Embedding skipped: daily AI budget reached (spent=$%.4f / $%.2f); "
+            "emitting %d NULL embeddings (re-embeddable later).",
+            budget.spent_usd,
+            budget.limit_usd,
+            len(texts),
+        )
+        return [None] * len(texts)
+
     client = voyageai.Client(api_key=settings.voyage_api_key)
     all_embeddings: list[list[float] | None] = []
+    total_tokens = 0
 
     for i in range(0, len(texts), BATCH_SIZE):
         batch = texts[i : i + BATCH_SIZE]
@@ -40,6 +57,7 @@ async def embed_texts(texts: list[str]) -> list[list[float] | None]:
                 input_type="document",
             )
             all_embeddings.extend(result.embeddings)
+            total_tokens += int(getattr(result, "total_tokens", 0) or 0)
         except Exception as e:
             logger.error(
                 "Embedding failed for batch %d (%d texts); emitting NULL "
@@ -51,6 +69,11 @@ async def embed_texts(texts: list[str]) -> list[list[float] | None]:
             # Emit None per item (NULL embedding) — never a zero vector. Length
             # is preserved so the caller's article/vector alignment stays stable.
             all_embeddings.extend([None] * len(batch))
+
+    # Record estimated Voyage spend for the daily ceiling (no-op if guard off).
+    await record_usage(
+        "voyage", MODEL, "embedder.embed_texts", voyage_cost(total_tokens)
+    )
 
     embedded = sum(1 for v in all_embeddings if v is not None)
     skipped = len(all_embeddings) - embedded

--- a/services/usage_tracker.py
+++ b/services/usage_tracker.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from typing import Any
+
+from app.config import settings
 
 logger = logging.getLogger("sift-api.usage")
 
@@ -15,6 +18,11 @@ PRICE_CACHE_READ_PER_M = 0.10  # 0.1x base input for cache hits
 
 # Web search tool pricing: $10 per 1,000 searches
 PRICE_WEB_SEARCH_PER_CALL = 0.010
+
+# Voyage AI voyage-3-lite embeddings (USD per 1M tokens). Voyage bills a small
+# per-token rate above a generous free monthly tier; this is a conservative
+# upper-bound estimate, used only for the daily cost ledger.
+PRICE_VOYAGE_PER_M = 0.02
 
 
 def log_usage(
@@ -63,6 +71,7 @@ def log_usage(
             "cost_usd": round(cost_usd, 6),
         }
         logger.info(json.dumps(payload))
+        _record_to_ledger(operation, model, round(cost_usd, 6))
         return payload
     except Exception as e:
         # Never let telemetry break the pipeline
@@ -83,3 +92,33 @@ def count_web_searches(response: Any) -> int:
         return count
     except Exception:
         return 0
+
+
+# Fire-and-forget tasks that persist usage to the daily cost ledger. We keep a
+# reference so the running loop doesn't garbage-collect them mid-flight.
+_pending_records: set = set()
+
+
+def voyage_cost(total_tokens: int) -> float:
+    """Estimated USD cost for a Voyage embedding call, for the daily ledger."""
+    return (total_tokens or 0) * PRICE_VOYAGE_PER_M / 1_000_000
+
+
+def _record_to_ledger(operation: str, model: str, cost_usd: float) -> None:
+    """Best-effort: persist a Claude call's cost to the daily ledger without
+    blocking the caller. No-op when the cost guard is disabled or when there's
+    no running event loop (sync contexts / unit tests)."""
+    if cost_usd <= 0 or not settings.ai_cost_guard_enabled:
+        return
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return  # no event loop to schedule onto
+    try:
+        from services.cost_guard import record_usage
+
+        task = loop.create_task(record_usage("anthropic", model, operation, cost_usd))
+        _pending_records.add(task)
+        task.add_done_callback(_pending_records.discard)
+    except Exception as e:  # never let telemetry break the caller
+        logger.debug("usage ledger scheduling failed for %s: %s", operation, e)

--- a/tests/test_compare_router.py
+++ b/tests/test_compare_router.py
@@ -5,6 +5,8 @@ from unittest.mock import AsyncMock, patch
 
 from fastapi.testclient import TestClient
 
+from services.cost_guard import BudgetDecision
+
 
 @pytest.fixture
 def client():
@@ -112,3 +114,47 @@ class TestCompareErrorSanitization:
             assert "secret" not in str(detail)
             assert detail["detail"] == "Comparison failed"
             assert detail["code"] == "COMPARISON_FAILED"
+
+
+class TestCompareCostCeiling:
+    def test_over_budget_blocks_without_calling_provider(self, client):
+        """When today's spend is over budget, the request is rejected 503 and the
+        compare workflow (the paid web-search path) is never invoked."""
+        blocked = BudgetDecision(False, "budget_exceeded", 11.0, 10.0)
+        with patch(
+            "app.routers.compare.check_budget",
+            new_callable=AsyncMock,
+            return_value=blocked,
+        ):
+            with patch(
+                "app.routers.compare.compare_graph.ainvoke", new_callable=AsyncMock
+            ) as ainvoke:
+                response = client.post(
+                    "/analyze/compare",
+                    json={"topic": "climate change", "sources": ["reuters"]},
+                    headers={"X-Pipeline-Key": "dev-key"},
+                )
+        assert response.status_code == 503
+        assert response.json()["detail"]["code"] == "AI_BUDGET_EXCEEDED"
+        ainvoke.assert_not_called()
+
+    def test_guard_unavailable_fails_closed_without_calling_provider(self, client):
+        """Fail-closed: when the guard can't verify budget (e.g. DB error), the
+        request is rejected 503 and the provider is never called."""
+        blocked = BudgetDecision(False, "guard_unavailable", 0.0, 10.0)
+        with patch(
+            "app.routers.compare.check_budget",
+            new_callable=AsyncMock,
+            return_value=blocked,
+        ):
+            with patch(
+                "app.routers.compare.compare_graph.ainvoke", new_callable=AsyncMock
+            ) as ainvoke:
+                response = client.post(
+                    "/analyze/compare",
+                    json={"topic": "climate change", "sources": ["reuters"]},
+                    headers={"X-Pipeline-Key": "dev-key"},
+                )
+        assert response.status_code == 503
+        assert response.json()["detail"]["code"] == "COST_GUARD_UNAVAILABLE"
+        ainvoke.assert_not_called()

--- a/tests/test_cost_guard.py
+++ b/tests/test_cost_guard.py
@@ -65,14 +65,16 @@ class TestCheckBudget:
         assert allowed.allowed is True
         assert allowed.reason == "within_budget"
 
-    def test_ledger_unavailable_fails_open(self):
+    def test_ledger_unavailable_fails_closed_when_enabled(self):
+        # A cost ceiling must not authorize paid calls when it can't verify
+        # spend — an enabled guard fails CLOSED on a ledger/DB error.
         with patch.object(cost_guard.settings, "ai_cost_guard_enabled", True):
             with patch.object(
                 cost_guard, "get_pool", AsyncMock(side_effect=RuntimeError("no pool"))
             ):
                 decision = asyncio.run(cost_guard.check_budget(1.0))
-        assert decision.allowed is True
-        assert decision.reason == "ledger_unavailable"
+        assert decision.allowed is False
+        assert decision.reason == "guard_unavailable"
 
 
 class TestAlert:

--- a/tests/test_cost_guard.py
+++ b/tests/test_cost_guard.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from services import cost_guard
+
+
+def _mock_pool(spent: float = 0.0):
+    pool = AsyncMock()
+    pool.fetchval = AsyncMock(return_value=spent)
+    pool.execute = AsyncMock()
+    return pool
+
+
+class TestCheckBudget:
+    def test_disabled_guard_always_allows_without_touching_db(self):
+        with patch.object(cost_guard.settings, "ai_cost_guard_enabled", False):
+            with patch.object(cost_guard, "get_pool", new_callable=AsyncMock) as gp:
+                decision = asyncio.run(cost_guard.check_budget(5.0))
+        assert decision.allowed is True
+        assert decision.reason == "guard_disabled"
+        gp.assert_not_called()
+
+    def test_below_limit_allows(self):
+        pool = _mock_pool(spent=2.0)
+        with patch.object(cost_guard.settings, "ai_cost_guard_enabled", True):
+            with patch.object(cost_guard.settings, "daily_ai_cost_limit_usd", 10.0):
+                with patch.object(cost_guard, "get_pool", AsyncMock(return_value=pool)):
+                    decision = asyncio.run(cost_guard.check_budget(1.0))
+        assert decision.allowed is True
+        assert decision.reason == "within_budget"
+        assert decision.spent_usd == 2.0
+
+    def test_at_or_above_limit_blocks(self):
+        pool = _mock_pool(spent=9.95)
+        with patch.object(cost_guard.settings, "ai_cost_guard_enabled", True):
+            with patch.object(cost_guard.settings, "daily_ai_cost_limit_usd", 10.0):
+                with patch.object(
+                    cost_guard.settings, "ai_cost_alert_threshold_ratio", 0.8
+                ):
+                    with patch.object(
+                        cost_guard, "get_pool", AsyncMock(return_value=pool)
+                    ):
+                        decision = asyncio.run(cost_guard.check_budget(0.10))
+        assert decision.allowed is False
+        assert decision.reason == "budget_exceeded"
+
+    def test_ledger_unavailable_fails_open(self):
+        with patch.object(cost_guard.settings, "ai_cost_guard_enabled", True):
+            with patch.object(
+                cost_guard, "get_pool", AsyncMock(side_effect=RuntimeError("no pool"))
+            ):
+                decision = asyncio.run(cost_guard.check_budget(1.0))
+        assert decision.allowed is True
+        assert decision.reason == "ledger_unavailable"
+
+
+class TestAlert:
+    def setup_method(self):
+        cost_guard._alerted_dates.clear()
+
+    def test_alert_fires_once_and_uses_sentry_when_configured(self):
+        pool = _mock_pool(spent=8.5)  # 85% of 10 → over the 0.8 threshold
+        with patch.object(cost_guard.settings, "ai_cost_guard_enabled", True):
+            with patch.object(cost_guard.settings, "daily_ai_cost_limit_usd", 10.0):
+                with patch.object(
+                    cost_guard.settings, "ai_cost_alert_threshold_ratio", 0.8
+                ):
+                    with patch.object(
+                        cost_guard.settings,
+                        "sentry_dsn",
+                        "https://k@o0.ingest.sentry.io/1",
+                    ):
+                        with patch.object(
+                            cost_guard, "get_pool", AsyncMock(return_value=pool)
+                        ):
+                            with patch.object(
+                                cost_guard.sentry_sdk, "capture_message"
+                            ) as cap:
+                                d1 = asyncio.run(cost_guard.check_budget())
+                                d2 = asyncio.run(cost_guard.check_budget())
+        assert d1.allowed is True and d2.allowed is True
+        cap.assert_called_once()  # de-duped to one alert per UTC day
+
+    def test_alert_without_sentry_dsn_does_not_fail(self):
+        pool = _mock_pool(spent=9.0)
+        with patch.object(cost_guard.settings, "ai_cost_guard_enabled", True):
+            with patch.object(cost_guard.settings, "daily_ai_cost_limit_usd", 10.0):
+                with patch.object(
+                    cost_guard.settings, "ai_cost_alert_threshold_ratio", 0.8
+                ):
+                    with patch.object(cost_guard.settings, "sentry_dsn", ""):
+                        with patch.object(
+                            cost_guard, "get_pool", AsyncMock(return_value=pool)
+                        ):
+                            with patch.object(
+                                cost_guard.sentry_sdk, "capture_message"
+                            ) as cap:
+                                decision = asyncio.run(cost_guard.check_budget())
+        assert decision.allowed is True
+        cap.assert_not_called()  # Sentry inert → logs only, no crash
+
+
+class TestRecordUsage:
+    def test_disabled_is_noop(self):
+        with patch.object(cost_guard.settings, "ai_cost_guard_enabled", False):
+            with patch.object(cost_guard, "get_pool", new_callable=AsyncMock) as gp:
+                asyncio.run(cost_guard.record_usage("anthropic", "m", "op", 0.5))
+        gp.assert_not_called()
+
+    def test_enabled_writes_to_ledger(self):
+        pool = _mock_pool()
+        with patch.object(cost_guard.settings, "ai_cost_guard_enabled", True):
+            with patch.object(cost_guard, "get_pool", AsyncMock(return_value=pool)):
+                asyncio.run(
+                    cost_guard.record_usage(
+                        "voyage", "voyage-3-lite", "embedder.embed_texts", 0.25
+                    )
+                )
+        pool.execute.assert_called_once()
+
+    def test_write_error_is_swallowed(self):
+        with patch.object(cost_guard.settings, "ai_cost_guard_enabled", True):
+            with patch.object(
+                cost_guard, "get_pool", AsyncMock(side_effect=RuntimeError("db down"))
+            ):
+                # Must not raise.
+                asyncio.run(cost_guard.record_usage("anthropic", "m", "op", 0.5))

--- a/tests/test_cost_guard.py
+++ b/tests/test_cost_guard.py
@@ -46,6 +46,25 @@ class TestCheckBudget:
         assert decision.allowed is False
         assert decision.reason == "budget_exceeded"
 
+    def test_proactive_estimate_blocks_before_spend_alone_would(self):
+        # Spent is under the limit (and under the alert ratio), but spent plus
+        # this call's estimate is not — the call is blocked before it crosses.
+        pool = _mock_pool(spent=7.0)
+        with patch.object(cost_guard.settings, "ai_cost_guard_enabled", True):
+            with patch.object(cost_guard.settings, "daily_ai_cost_limit_usd", 10.0):
+                with patch.object(
+                    cost_guard.settings, "ai_cost_alert_threshold_ratio", 0.8
+                ):
+                    with patch.object(
+                        cost_guard, "get_pool", AsyncMock(return_value=pool)
+                    ):
+                        blocked = asyncio.run(cost_guard.check_budget(4.0))
+                        allowed = asyncio.run(cost_guard.check_budget(0.5))
+        assert blocked.allowed is False
+        assert blocked.reason == "budget_exceeded"
+        assert allowed.allowed is True
+        assert allowed.reason == "within_budget"
+
     def test_ledger_unavailable_fails_open(self):
         with patch.object(cost_guard.settings, "ai_cost_guard_enabled", True):
             with patch.object(

--- a/tests/test_embedder.py
+++ b/tests/test_embedder.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
+from services.cost_guard import BudgetDecision
 from services.embedder import BATCH_SIZE, embed_texts
 
 ZERO_VECTOR = [0.0] * 512
@@ -58,4 +59,20 @@ class TestEmbedTexts:
         assert all(v is not None and len(v) == 512 for v in out[:BATCH_SIZE])
         # ...second (failed) batch is None, never zero vectors.
         assert out[BATCH_SIZE:] == [None, None, None]
+        assert ZERO_VECTOR not in out
+
+    def test_returns_none_when_cost_guard_blocks(self):
+        """Fail-closed / over-budget: when the cost guard blocks, no Voyage call
+        is made and every text gets a NULL embedding (re-embeddable later)."""
+        texts = ["a", "b", "c"]
+        blocked = BudgetDecision(False, "guard_unavailable", 0.0, 10.0)
+        with patch(
+            "services.embedder.check_budget",
+            new_callable=AsyncMock,
+            return_value=blocked,
+        ):
+            with patch("services.embedder.voyageai.Client") as Client:
+                out = asyncio.run(embed_texts(texts))
+        assert out == [None, None, None]
+        Client.assert_not_called()  # provider never constructed/called
         assert ZERO_VECTOR not in out


### PR DESCRIPTION
## What
Adds a **backend-only** daily AI cost ceiling for sift-api's live paid paths. **Inert by default** — no behavior change unless `AI_COST_GUARD_ENABLED=true`.

Closes #70

## Scope (Scope A — backend-only)
- Enforces the daily ceiling for **paid calls made by sift-api** — the live paths the issue names: **Claude web-search (compare)** and **Voyage embeddings**.
- The ledger lives in the **shared Neon/Postgres DB** so the upcoming D35 migration (sift-api#79) can reuse it.
- **Does not** wire the current frontend topic-search route into the ceiling.

## How
- **`services/cost_guard.py`** — `check_budget()` + `record_usage()` over an `ai_usage_daily` ledger keyed by `(UTC date, provider, model, operation)`.
  - **Proactive**: blocks when today's spend **+ this call's conservative estimate** would exceed the limit (not just after the fact).
  - **Ceiling-hit → fail closed**: skip the provider call, degrade gracefully.
  - **DB/ledger error (guard enabled) → fail closed**: if spend can't be verified, paid calls are **not** authorized (`reason="guard_unavailable"`). A cost ceiling must not permit spend in the exact failure mode where spend can't be measured. (Guard disabled = always a no-op.)
  - **80% alert**: structured log + Sentry `capture_message` when `SENTRY_DSN` is configured, logs-only when Sentry is inert. De-duped to once per UTC day.
- **Ledger schema** in all three places: `init.sql`, `migrations/011_ai_usage_daily.sql`, and `app/db.py:_apply_migrations` (idempotent startup apply).
- **Recording** — `usage_tracker.log_usage` feeds every Claude call's estimated cost into the ledger (best-effort, non-blocking); `embedder` records Voyage spend.
- **Enforcement** —
  - **Compare router**: returns `503` before invoking the live web-search workflow — `AI_BUDGET_EXCEEDED` when over budget, `COST_GUARD_UNAVAILABLE` when the guard can't verify. Provider never called.
  - **Embedder**: emits `NULL` embeddings (re-embeddable later — same contract as a failed batch). Voyage never called.
- **Config** (`AI_COST_GUARD_ENABLED` default `false`, `DAILY_AI_COST_LIMIT_USD` default `10.0`, `AI_COST_ALERT_THRESHOLD_RATIO` default `0.8`) + `.env.example` + README.

## Notes
- **This closes the sift-api cost ceiling path. Frontend topic-search fallback remains a temporary D35 exception and is covered by sift-api#79.**
- **Fail-closed tradeoff**: when the guard is *enabled* and the DB is unavailable, paid calls are blocked (compare `503`, embeddings `NULL`) until the ledger is readable again. Deliberate — for a spend ceiling, not spending is the safe direction when spend can't be measured. The guard is **off by default**, so this only applies once explicitly enabled.
- This is the spend-control layer; Sentry (sift-api#81) stays the error-monitoring layer. Profiling, logs, cron monitoring, and custom AI telemetry are not in scope.

## Validation
- ✅ `ruff check .` — all checks passed
- ✅ `pytest tests/ -v` — **168 passed** (cost-guard unit tests + compare/embedder integration tests proving the provider is **not** called on a budget block or guard error)
- ✅ Migration `011` applied against pgvector: idempotent; upsert accumulates; daily-SUM query returns the expected total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
