### PR TITLE
chore: enable Dependabot for backend dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      python-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Adds Dependabot config for sift-api dependency maintenance.

Includes:
- Python/pip dependency updates
- Docker dependency updates, if configured
- GitHub Actions updates

This is a config-only housekeeping PR and does not affect runtime behavior.
