### PR TITLE
docs: accuracy fixes + feed-count drift guard + pipeline-heartbeat backstop

### DIFF
--- a/.github/workflows/pipeline-heartbeat.yml
+++ b/.github/workflows/pipeline-heartbeat.yml
@@ -1,0 +1,67 @@
+name: Pipeline heartbeat
+
+# Independent backstop + staleness alarm for the in-process 30-min scheduler
+# (app/main.py:_scheduled_refresh). If the Railway process dies or restarts and
+# the loop stops, ingestion silently stalls — /health exposes last_pipeline_run
+# but nothing watches it. This job watches it: it re-triggers a refresh and
+# fails (→ GitHub notification) when the feed goes stale. Vercel Cron can't do
+# this on Hobby (capped at once/day); GitHub Actions schedule is free + 30-min.
+#
+# Required repo secrets (job no-ops cleanly if unset, so it never spams):
+#   SIFT_API_URL       e.g. https://sift-api-production.up.railway.app
+#   PIPELINE_API_KEY   same shared secret the backend checks via X-Pipeline-Key
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  heartbeat:
+    name: Check ingestion freshness
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check /health and self-heal if stale
+        env:
+          SIFT_API_URL: ${{ secrets.SIFT_API_URL }}
+          PIPELINE_API_KEY: ${{ secrets.PIPELINE_API_KEY }}
+          MAX_AGE_MIN: "70" # scheduler runs every 30 min; 70 ≈ two missed cycles
+        run: |
+          set -euo pipefail
+          if [ -z "${SIFT_API_URL:-}" ] || [ -z "${PIPELINE_API_KEY:-}" ]; then
+            echo "SIFT_API_URL / PIPELINE_API_KEY secrets not set — skipping heartbeat."
+            exit 0
+          fi
+
+          health=$(curl -fsS --max-time 20 "$SIFT_API_URL/health")
+          echo "health: $health"
+          last=$(echo "$health" | jq -r '.last_pipeline_run // empty')
+
+          stale=false
+          if [ -z "$last" ]; then
+            echo "last_pipeline_run is null — treating as stale."
+            stale=true
+          else
+            last_epoch=$(date -u -d "$last" +%s 2>/dev/null || echo 0)
+            now_epoch=$(date -u +%s)
+            age_min=$(( (now_epoch - last_epoch) / 60 ))
+            echo "last_pipeline_run=$last (age ${age_min} min, threshold ${MAX_AGE_MIN})"
+            if [ "$last_epoch" -eq 0 ] || [ "$age_min" -gt "$MAX_AGE_MIN" ]; then
+              stale=true
+            fi
+          fi
+
+          if [ "$stale" = true ]; then
+            echo "::warning::Ingestion is stale — triggering a refresh."
+            curl -fsS --max-time 280 -X POST "$SIFT_API_URL/pipeline/refresh" \
+              -H "Content-Type: application/json" \
+              -H "X-Pipeline-Key: $PIPELINE_API_KEY" \
+              -d '{}' || echo "refresh trigger failed"
+            echo "::error::Ingestion was stale (last run > ${MAX_AGE_MIN} min ago); refresh re-triggered. Investigate the in-process scheduler."
+            exit 1
+          fi
+
+          echo "Ingestion fresh — no action needed."

--- a/README.md
+++ b/README.md
@@ -8,11 +8,14 @@ Handles the background content pipeline (RSS feeds → Claude Haiku summaries �
 
 ```
 Railway asyncio scheduler (every 30 min)
-  → LangGraph pipeline: fetch_rss → deduplicate → summarize (Claude) → embed (Voyage) → store (Postgres)
+  → LangGraph pipeline: fetch_rss → deduplicate → summarize (Claude) → context/primer (Claude, batch) → embed (Voyage) → link_entities → store (Postgres)
+      → nested LangGraph story-threading (per category): fetch_articles → extract_entities → cluster (Claude) → synthesize_and_store
 
 User compare request (via Vercel proxy)
-  → LangGraph compare: search_sources (parallel) → extract_and_compare → format_response
+  → LangGraph compare: search_sources (parallel, Claude web_search) → extract_and_compare → format_response
 ```
+
+This service compiles **three** LangGraph `StateGraph`s: the ingestion **pipeline**, a **story-threading** graph the pipeline invokes per category, and the on-demand **compare** graph. (Two are user-facing workflows; story-threading is nested inside ingestion.)
 
 User-facing reads happen in the Next.js frontend — this service handles background AI processing and on-demand comparison.
 
@@ -106,10 +109,11 @@ sift-api/
 │       ├── pipeline.py      # POST /pipeline/refresh
 │       └── compare.py       # POST /analyze/compare
 ├── workflows/
-│   ├── pipeline_workflow.py # LangGraph: fetch→dedup→summarize→embed→store
-│   └── compare_workflow.py  # LangGraph: search→extract→compare→format
+│   ├── pipeline_workflow.py # LangGraph: fetch_rss→dedup→summarize→context→primer→embed→link_entities→store
+│   ├── story_workflow.py    # LangGraph: fetch_articles→extract_entities→cluster→synthesize_and_store (nested in pipeline)
+│   └── compare_workflow.py  # LangGraph: search_sources→extract_and_compare→format_response
 ├── services/
-│   ├── rss.py               # 100+ RSS feeds, feedparser, image extraction
+│   ├── rss.py               # 58 RSS feeds across the spectrum, feedparser, image extraction
 │   ├── summarizer.py        # Claude Haiku 4.5 batch summarization
 │   ├── context_generator.py # why_it_matters line + importance score
 │   ├── primer_generator.py  # context_primer: background + glossary terms
@@ -119,7 +123,7 @@ sift-api/
 │   └── deduplicator.py      # Postgres dedup check
 ├── tests/
 ├── docker-compose.yml       # Postgres 16 + pgvector (local dev)
-├── init.sql                 # DB schema (4 tables)
+├── init.sql                 # DB schema (9 tables; civic profile tables via migrations/)
 ├── Dockerfile               # Production image
 ├── railway.toml             # Railway deployment config
 └── .github/workflows/ci.yml # Ruff + pytest on PR/push

--- a/tests/test_rss.py
+++ b/tests/test_rss.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import re
+from pathlib import Path
+
 from services.rss import stable_hash, _base36, parse_feed, FEEDS
 
 
@@ -113,3 +116,17 @@ class TestFeedConfig:
             name, url = feed
             assert isinstance(name, str)
             assert url.startswith("http")
+
+    def test_readme_feed_count_matches(self):
+        # Drift guard: the README's "NN RSS feeds" claim must match len(FEEDS).
+        # Code is the single source of truth; this fails the build if the doc
+        # and the feed list diverge — the exact regression that left the README
+        # claiming "100+" while FEEDS held 58.
+        readme = Path(__file__).resolve().parents[1] / "README.md"
+        text = readme.read_text(encoding="utf-8")
+        match = re.search(r"(\d+)\s+RSS feeds", text)
+        assert match, "Could not find an 'NN RSS feeds' claim in README.md"
+        assert int(match.group(1)) == len(FEEDS), (
+            f"README says {match.group(1)} RSS feeds but FEEDS has {len(FEEDS)}. "
+            "Update the count in sift-api/README.md to match."
+        )


### PR DESCRIPTION
## What
Documentation-accuracy fixes from a code audit, plus a CI backstop for ingestion freshness.

## Changes
**Docs (`README.md`)** — align with the actual code:
- Architecture diagram: real 8-node pipeline (`fetch_rss → deduplicate → summarize → context → primer → embed → link_entities → store`) + the nested story-threading graph; name all **three** compiled `StateGraph`s (not two)
- workflows tree: add `story_workflow.py`
- `rss.py` "100+ RSS feeds" → **58**; `init.sql` "4 tables" → **9** (+ civic profile tables via migrations)

**Drift guard (`tests/test_rss.py`)**
- New `test_readme_feed_count_matches`: parses the README's "NN RSS feeds" and asserts it equals `len(FEEDS)`, so the doc can't silently drift again.

**CI (`.github/workflows/pipeline-heartbeat.yml`)** — new
- Independent backstop + staleness alarm for the in-process 30-min scheduler (`app/main.py:_scheduled_refresh`). Every 30 min it checks `/health.last_pipeline_run`; if stale it re-triggers `/pipeline/refresh` and fails the job (notification). No-ops cleanly when `SIFT_API_URL` / `PIPELINE_API_KEY` secrets are unset, so it never spams.

## Activation
Workflow is inert until repo secrets are set — tracked in #102.

## Verification
- `pytest tests/test_rss.py` → 18/18 (incl. the new drift guard); `ruff check .` clean
- heartbeat YAML parses; logic guarded to no-op without secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)